### PR TITLE
Adds a flag that allows users to disable authentication requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ Rosetta can be configured via the following parameters, to be defined in your pr
 * ``ROSETTA_MESSAGES_SOURCE_LANGUAGE_CODE`` and ``ROSETTA_MESSAGES_SOURCE_LANGUAGE_NAME``: Change these if the source language in your PO files isn't English. Default to ``'en'`` and ``'English'`` respectively.
 * ``ROSETTA_WSGI_AUTO_RELOAD`` and ``ROSETTA_UWSGI_AUTO_RELOAD``: When running WSGI daemon mode, using ``mod_wsgi`` 2.0c5 or later, this setting controls whether the contents of the gettext catalog files should be automatically reloaded by the WSGI processes each time they are modified. For performance reasons, this setting should be disabled in production environments. Default to ``False``.
 * ``ROSETTA_EXCLUDED_APPLICATIONS``: Exclude applications defined in this list from being translated. Defaults to ``()``.
+* ``ROSETTA_REQUIRES_AUTH``: Require authentication for all Rosetta views. Defaults to ``True``.
 
 ********
 Security


### PR DESCRIPTION
In our environment, we don't need or want the rosetta app to require authentication. This pull request allows a developer to disable authentication for rosetta by setting ROSETTA_REQUIRES_AUTH = False.

As an added bonus, this flag allows rosetta to be used on django apps that don't have a database. The session framework will just need to be configured to use a backend that isn't the default database backend and they should be all set.

Here's an example configuration:

```
# Rosetta needs the session framework, but there isn't a db, using files
SESSION_ENGINE = 'django.contrib.sessions.backends.file'

MIDDLEWARE_CLASSES = (
    'django.contrib.sessions.middleware.SessionMiddleware',
    # We need an anonymous user object, because rosetta passed it around
    'django.contrib.auth.middleware.AuthenticationMiddleware',
)

INSTALLED_APPS = (
    # Rosetta needs the admin section's static assets. We list it here
    # just so that the staticfiles app knows to grab them.
    'django.contrib.sessions',
    'django.contrib.admin',
    'rosetta',
)
```
