### PR TITLE
Prevent context issue w/ django.contrib.messages

### DIFF
--- a/rosetta/templates/rosetta/pofile.html
+++ b/rosetta/templates/rosetta/pofile.html
@@ -71,7 +71,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for  message in messages %}
+                    {% for message in rosetta_messages %}
                     <tr class="{% cycle row1,row2 %}">
                         {% if message.msgid_plural %}
                             <td class="original plural">

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -194,7 +194,7 @@ def home(request):
             page = int(request.GET.get('page'))
         else:
             page = 1
-        messages = paginator.page(page).object_list
+        rosetta_messages = paginator.page(page).object_list
         if rosetta_settings.MAIN_LANGUAGE and rosetta_settings.MAIN_LANGUAGE != rosetta_i18n_lang_code:
 
             main_language = None
@@ -207,7 +207,7 @@ def home(request):
             po = pofile(fl)
 
             main_messages = []
-            for message in messages:
+            for message in rosetta_messages:
                 message.main_lang = po.find(message.msgid).msgstr
 
         needs_pagination = paginator.num_pages > 1


### PR DESCRIPTION
Due to the situation we have at work, I encounter a problem whereby the variable `messages` in the template render context is overwritten by the variable `messages` provided by `django.contrib.messages` which is passed in via a `RequestContext`.

This commit simply renames `messages` to `rosetta_messages` to avoid this problem.

See https://docs.djangoproject.com/en/1.3/ref/contrib/messages/#displaying-messages
