### PR TITLE
Show bing suggest errors.

### DIFF
--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -1,3 +1,5 @@
+{% load rosetta %}
+
 google.setOnLoadCallback(function() {
     $('.location a').show().toggle(function() {
         $('.hide', $(this).parent()).show();
@@ -13,7 +15,7 @@ google.setOnLoadCallback(function() {
         var orig = $('.original .message', a.parents('tr')).html();
         var trans=$('textarea',a.parent());
         var sourceLang = '{{ MESSAGES_SOURCE_LANGUAGE_CODE }}';
-        var destLang = '{{ rosetta_i18n_lang_code|slice:":2" }}';
+        var destLang = '{{ rosetta_i18n_lang_code }}';
         var app_id = '{{ BING_APP_ID }}';
         var apiUrl = "http://api.microsofttranslator.com/V2/Ajax.svc/Translate";
 
@@ -31,13 +33,13 @@ google.setOnLoadCallback(function() {
             appid: app_id,
             from: sourceLang,
             to: destLang,
+            oncomplete: "onTranslationComplete",
             text: orig
         };
         $.ajax({
             url: apiUrl,
             data: apiData,
-            dataType: 'jsonp',
-            jsonpCallback: 'onTranslationComplete'});
+            dataType: 'jsonp'});
     });
 {% endif %}
 

--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -4,53 +4,43 @@ google.setOnLoadCallback(function() {
     }, function() {
         $('.hide', $(this).parent()).hide();
     });
+
 {% if ENABLE_TRANSLATION_SUGGESTIONS and BING_APP_ID %}    
-    $('a.suggest').click(function() {
-        var a = $(this),
-            str = a.html(),
-            orig = $('.original .message', a.parents('tr')).html(),
-            trans=$('textarea',a.parent()),
-            sourceLang = '{{MESSAGES_SOURCE_LANGUAGE_CODE}}',
-            destLang = '{{rosetta_i18n_lang_code|slice:":2"}}',
-            app_id = '{{BING_APP_ID}}';
-        
-        orig = unescape(orig).replace(/<br\s?\/?>/g,'\n').replace(/<code>/g,'').replace(/<\/code>/g,'').replace(/&gt;/g,'>').replace(/&lt;/g,'<');
+    $('a.suggest').click(function(e){
+        e.preventDefault();
+        var a = $(this);
+        var str = a.html();
+        var orig = $('.original .message', a.parents('tr')).html();
+        var trans=$('textarea',a.parent());
+        var sourceLang = '{{ MESSAGES_SOURCE_LANGUAGE_CODE }}';
+        var destLang = '{{ rosetta_i18n_lang_code|slice:":2" }}';
+        var app_id = '{{ BING_APP_ID }}';
+        var apiUrl = "http://api.microsofttranslator.com/V2/Ajax.svc/Translate";
+
+        orig = unescape(orig).replace(/<br\s?\/?>/g,'\n').replace(/<code>/,'').replace(/<\/code>/g,'').replace(/&gt;/g,'>').replace(/&lt;/g,'<');
         a.attr('class','suggesting').html('...');
         window.onTranslationComplete = function(resp) {
             trans.val(unescape(resp).replace(/&#39;/g,'\'').replace(/&quot;/g,'"').replace(/%\s+(\([^\)]+\))\s*s/g,' %$1s '));
             a.hide();
-            
         };
-        var s = document.createElement("script");
-            s.src = "http://api.microsofttranslator.com/V2/Ajax.svc/Translate?oncomplete=onTranslationComplete&appId="+app_id +"&from=" + sourceLang + "&to=" + destLang + "&text=" + orig;
-            document.getElementsByTagName("head")[0].appendChild(s);
-
-        /*
-        google.language.translate(orig, , function(result) {
-            if (!result.error) {
-                trans.val(unescape(result.translation).replace(/&#39;/g,'\'').replace(/&quot;/g,'"').replace(/%\s+(\([^\)]+\))\s*s/g,' %$1s '));
-                a.hide();
-            } else {
-                a.hide().before($('<span class="alert">'+result.error.message+'</span>'));
-            }
-        });
-        */
-        return false;
+        window.onTranslationError = function(response){
+            a.text(response);
+        };
+        var apiData = {
+            onerror: 'onTranslationError',
+            appid: app_id,
+            from: sourceLang,
+            to: destLang,
+            text: orig
+        };
+        $.ajax({
+            url: apiUrl,
+            data: apiData,
+            dataType: 'jsonp',
+            jsonpCallback: 'onTranslationComplete'});
     });
-    
-    
-    $('#translate-all').submit(function() {
-        $('a.suggest').click();
-        return false;
-    });
-    $('.checkall').click(function(){
-        $('td.c input').attr('checked', '');
-        $('td.c input').attr('value', '0');
-    });
-    
-    
-    
 {% endif %}
+
     $('td.plural').each(function(i) {
         var td = $(this), trY = parseInt(td.closest('tr').offset().top);
         $('textarea', $(this).closest('tr')).each(function(j) {

--- a/rosetta/templatetags/rosetta.py
+++ b/rosetta/templatetags/rosetta.py
@@ -4,6 +4,7 @@ from django.utils.html import escape
 import re
 from django.template import Node
 from django.utils.encoding import smart_str, smart_unicode
+from django.template.defaultfilters import stringfilter
 
 register = template.Library()
 rx = re.compile(r'(%(\([^\s\)]*\))?[sd])')
@@ -27,7 +28,6 @@ def minus(a,b):
     except:
         return 0
 minus=register.filter(minus)
-    
 
 def gt(a,b):
     try:


### PR DESCRIPTION
Bing translate returns an error string that doesn't fire the callback when you supply a language that it doesn't recognize (like zh for Chinese), rosetta would display indefinitely show "...", this patch replaces the link text with the error message using the undocumented onerror callback.

If anyone is interested hte Bing API claims to take a [639-1](http://msdn.microsoft.com/en-us/library/ff512399.aspx) languageCode which should be `zh` but that gives an error. Instead it expects `zh-CHS` for simpified and `zh-CHT` for traditional. `zh_HK` doesn't work. This is how I encountered the error.
