### PR TITLE
correctly handle plural strings that have a leading/trailing newline

### DIFF
--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -93,7 +93,7 @@ def home(request):
                     if entry:
                         old_msgstr = entry.msgstr
                         if plural_id is not None:
-                            plural_string = fix_nls(entry.msgstr_plural[plural_id], value)
+                            plural_string = fix_nls(entry.msgid_plural, value)
                             entry.msgstr_plural[plural_id] = plural_string
                         else:
                             entry.msgstr = fix_nls(entry.msgid, value)


### PR DESCRIPTION
We had a pluralised string that had a leading \n in the msgid (and msgid_plural), however the _fix_nl was not fixing it, because it was being called with the msgstr[1]. Ergo if you entered a non-newline msgstr, it would nor prefix the \n, and compilemessages would throw an error

this patch fixes that problem.
