### PR TITLE
Added msgctxt for entry's md5.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 .svnexternals
 build
 rosetta/locale/xx/LC_MESSAGES/*.mo
+/.settings
+/.project

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -56,7 +56,11 @@ def home(request):
         if rosetta_i18n_write:
             rosetta_i18n_pofile = pofile(rosetta_i18n_fn, wrapwidth=rosetta_settings.POFILE_WRAP_WIDTH)
             for entry in rosetta_i18n_pofile:
-                entry.md5hash = hashlib.md5(entry.msgid.encode("utf8") + entry.msgstr.encode("utf8")).hexdigest()
+                entry.md5hash = hashlib.md5(
+                    entry.msgid.encode("utf8") +
+                    entry.msgstr.encode("utf8") +
+                    (entry.msgctxt and entry.msgctxt.encode("utf8") or "") 
+                ).hexdigest()
 
         else:
             rosetta_i18n_pofile = request.session.get('rosetta_i18n_pofile')
@@ -344,7 +348,11 @@ def lang_sel(request, langid, idx):
         request.session['rosetta_i18n_fn'] = file_
         po = pofile(file_)
         for entry in po:
-            entry.md5hash = hashlib.md5(entry.msgid.encode("utf8") + entry.msgstr.encode("utf8")).hexdigest()
+            entry.md5hash = hashlib.md5(
+                entry.msgid.encode("utf8") +
+                entry.msgstr.encode("utf8") +
+                (entry.msgctxt and entry.msgctxt.encode("utf8") or "")
+            ).hexdigest()
 
         request.session['rosetta_i18n_pofile'] = po
         try:


### PR DESCRIPTION
Bug:
You couldn't change text for record with context if in database exist record with the same msgid and msgstr.
Fix:
Key for entry md5 also must include  msgctxt.
