### PR TITLE
change to def proces to display the actual po file that contains the error

### DIFF
--- a/rosetta/polib.py
+++ b/rosetta/polib.py
@@ -1310,7 +1310,7 @@ class _POFileParser(object):
             if action():
                 self.current_state = state
         except Exception:
-            raise IOError('Syntax error in po file (line %s)' % linenum)
+            raise IOError('Syntax error in po file: %s (line %s)' % (self.instance.fpath, linenum))
 
     # state handlers
 


### PR DESCRIPTION
Better to both display filepath and line number i think. This saves me some time searching.
