### PR TITLE
added `ROSETTA_POFILENAMES` setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,13 +4,13 @@ Rosetta
 
 Rosetta is a `Django <http://www.djangoproject.com/>`_ application that eases the translation process of your Django projects.
 
-Because it doesn't export any models, Rosetta doesn't create any tables in your project's database. Rosetta can be installed and uninstalled by simply adding and removing a single entry in your project's `INSTALLED_APPS` and a single line in your main ``urls.py`` file. 
+Because it doesn't export any models, Rosetta doesn't create any tables in your project's database. Rosetta can be installed and uninstalled by simply adding and removing a single entry in your project's `INSTALLED_APPS` and a single line in your main ``urls.py`` file.
 
 ********
 Features
 ********
 
-* Database independent 
+* Database independent
 * Reads and writes your project's `gettext` catalogs (po and mo files)
 * Installed and uninstalled in under a minute
 * Uses Django's admin interface CSS
@@ -34,7 +34,7 @@ To install Rosetta:
 3. Add an URL entry to your project's ``urls.py``, for example::
 
     from django.conf import settings
-    
+
     if 'rosetta' in settings.INSTALLED_APPS:
         urlpatterns += patterns('',
             url(r'^rosetta/', include('rosetta.urls')),
@@ -61,14 +61,15 @@ Rosetta can be configured via the following parameters, to be defined in your pr
 * ``ROSETTA_REQUIRES_AUTH``: Require authentication for all Rosetta views. Defaults to ``True``.
 * ``ROSETTA_POFILE_WRAP_WIDTH``: Sets the line-length of the edited PO file. Set this to ``0`` to mimic ``makemessage``'s ``--no-wrap`` option. Defaults to ``78``.
 * ``ROSETTA_STORAGE_CLASS``: See the note below on Storages. Defaults to ``rosetta.storage.CacheRosettaStorage``
+* ``ROSETTA_POFILENAMES``: Defines which po filenames are exposed in the web interface. Defaults to ``('django.po', 'djangojs.po')``
 
 ********
 Storages
 ********
 
-To prevent re-reading and parsing the PO file catalogs over and over again, Rosetta stores them in a volatile location. This can be either the HTTP session or the Django cache. 
+To prevent re-reading and parsing the PO file catalogs over and over again, Rosetta stores them in a volatile location. This can be either the HTTP session or the Django cache.
 
-Django 1.4 has introduced a signed cookie session backend, which stores the whole content of the session in an encrypted cookie. Unfortunately this doesn't work with large PO files, as the limit of 4096 chars that can be stored in a cookie are easily exceeded. 
+Django 1.4 has introduced a signed cookie session backend, which stores the whole content of the session in an encrypted cookie. Unfortunately this doesn't work with large PO files, as the limit of 4096 chars that can be stored in a cookie are easily exceeded.
 
 In this case the Cache-based backend should be used (by setting ``ROSETTA_STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'``). Please make sure that a proper CACHES backend is configured in your Django settings.
 
@@ -81,7 +82,7 @@ Security
 Because Rosetta requires write access to some of the files in your Django project, access to the application is restricted to the administrator user only (as defined in your project's Admin interface)
 
 If you wish to grant editing access to other users:
- 
+
 1. Create a 'translators' group in your admin interface
 2. Add the user you wish to grant translating rights to this group
 

--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -51,3 +51,6 @@ POFILE_WRAP_WIDTH = getattr(settings, 'ROSETTA_POFILE_WRAP_WIDTH', 78)
 
 # Storage class to handle temporary data storage
 STORAGE_CLASS = getattr(settings, 'ROSETTA_STORAGE_CLASS', 'rosetta.storage.CacheRosettaStorage')
+
+# Allow overriding of the default filenames, you mostly won't need to change this
+POFILENAMES = getattr(settings, 'ROSETTA_POFILENAMES', ('django.po', 'djangojs.po'))

--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -53,7 +53,7 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
             app = __import__(appname, {}, {}, [])
 
         apppath = os.path.normpath(os.path.abspath(os.path.join(os.path.dirname(app.__file__), 'locale')))
-        
+
 
         # django apps
         if 'contrib' in apppath and 'django' in apppath and not django_apps:
@@ -62,18 +62,18 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
         # third party external
         if not third_party_apps and abs_project_path not in apppath:
             continue
-            
+
         # local apps
         if not project_apps and abs_project_path in apppath:
             continue
-            
-        
+
+
         if os.path.isdir(apppath):
             paths.append(apppath)
-            
-            
-        
-            
+
+
+
+
     ret = set()
     langs = (lang,)
     if u'-' in lang:
@@ -82,12 +82,12 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
     elif u'_' in lang:
         _l,_c = map(lambda x:x.lower(),lang.split(u'_'))
         langs += (u'%s-%s' %(_l, _c), u'%s-%s' %(_l, _c.upper()), )
-        
+
     paths = map(os.path.normpath, paths)
     for path in paths:
         for lang_ in langs:
             dirname = os.path.join(path, lang_, 'LC_MESSAGES')
-            for fn in ('django.po','djangojs.po',):
+            for fn in rosetta_settings.POFILENAMES:
                 filename = os.path.join(dirname, fn)
                 if os.path.isfile(filename):
                     ret.add(os.path.abspath(filename))
@@ -95,19 +95,19 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
 
 def pagination_range(first,last,current):
     r = []
-    
+
     r.append(first)
     if first + 1 < last: r.append(first+1)
-    
+
     if current -2 > first and current -2 < last: r.append(current-2)
     if current -1 > first and current -1 < last: r.append(current-1)
     if current > first and current < last: r.append(current)
     if current + 1 < last and current+1 > first: r.append(current+1)
     if current + 2 < last and current+2 > first: r.append(current+2)
-    
+
     if last-1 > first: r.append(last-1)
     r.append(last)
-    
+
     r = list(set(r))
     r.sort()
     prev = 10000


### PR DESCRIPTION
We needed to override the filenames that are picked up by rosetta to allow our translation team to translate more than just the django translations.

Seems like a pretty unintrusive patch, so figured I'd share!
