### PR TITLE
New quoted URL system in django 1.5

### DIFF
--- a/rosetta/templates/rosetta/base.html
+++ b/rosetta/templates/rosetta/base.html
@@ -24,7 +24,7 @@
         <div id="header">
             {% block header %}
             <div id="branding">
-                <h1 id="site-name"><a href="{% url rosetta-pick-file %}">Rosetta</a> </h1>
+                <h1 id="site-name"><a href="{% url 'rosetta-pick-file' %}">Rosetta</a> </h1>
             </div>
             {% endblock %}
         </div>

--- a/rosetta/templates/rosetta/languages.html
+++ b/rosetta/templates/rosetta/languages.html
@@ -4,7 +4,7 @@
 {% block pagetitle %}{{block.super}} - {% trans "Language selection" %}{% endblock %}
 
 {% block breadcumbs %}
-    <div><a href="{% url rosetta-pick-file %}">{% trans "Home" %}</a> &rsaquo; {% trans "Language selection" %}</div>
+    <div><a href="{% url 'rosetta-pick-file' %}">{% trans "Home" %}</a> &rsaquo; {% trans "Language selection" %}</div>
     {% if do_session_warn %}<p class="errornote session-warn">{% trans "Couldn't load the specified language file. This usually happens when using the Encrypted Cookies Session Storage backend on Django 1.4 or higher.<br/>Setting ROSETTA_STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage' in your settings file should fix this." %}</p>{% endif %}
 {% endblock %}
 
@@ -40,7 +40,7 @@
                 <tbody>
                     {% for app,path,po in pos %}
                     <tr class="{% cycle row1,row2 %}">
-                        <td><a href="{% url rosetta-language-selection lid,forloop.counter0 %}{% if do_django %}?django{% endif %}{% if do_rosetta %}?rosetta{% endif %}">{{ app|title }}</a></td>
+                        <td><a href="{% url 'rosetta-language-selection' lid forloop.counter0 %}{% if do_django %}?django{% endif %}{% if do_rosetta %}?rosetta{% endif %}">{{ app|title }}</a></td>
                         <td class="ch-progress r">{{po.percent_translated|floatformat:2}}%</td>
                         {% with po.untranslated_entries|length as len_untranslated_entries %}
                         <td class="ch-messages r">{{po.translated_entries|length|add:len_untranslated_entries}}</td>

--- a/rosetta/templates/rosetta/pofile.html
+++ b/rosetta/templates/rosetta/pofile.html
@@ -5,8 +5,8 @@
     {{block.super}}
     <div id="user-tools">
         <p>
-            <span><a href="{% url rosetta-pick-file %}">{% trans "Pick another file" %}</a> / 
-            <a href="{% url rosetta-download-file %}">{% trans "Download this catalog" %}</a></span>
+            <span><a href="{% url 'rosetta-pick-file' %}">{% trans "Pick another file" %}</a> / 
+            <a href="{% url 'rosetta-download-file' %}">{% trans "Download this catalog" %}</a></span>
         </p>
     </div>
     <script type="text/javascript">
@@ -18,7 +18,7 @@
 
 {% block breadcumbs %}
     <div>
-        <a href="{% url rosetta-pick-file %}">{% trans "Home" %}</a> &rsaquo; 
+        <a href="{% url 'rosetta-pick-file' %}">{% trans "Home" %}</a> &rsaquo; 
         {{ rosetta_i18n_lang_name }} &rsaquo; 
         {{ rosetta_i18n_app|title }} &rsaquo; 
         {% blocktrans with rosetta_i18n_pofile.percent_translated|floatformat:2 as percent_translated  %}Progress: {{ percent_translated }}%{% endblocktrans %}


### PR DESCRIPTION
With django 1.5, {% url 'view_name' param1 param2 %} syntax is required. This commit fixes that problem.
