### PR TITLE
future: extra unused pos

### DIFF
--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -51,3 +51,6 @@ POFILE_WRAP_WIDTH = getattr(settings, 'ROSETTA_POFILE_WRAP_WIDTH', 78)
 
 # Storage class to handle temporary data storage
 STORAGE_CLASS = getattr(settings, 'ROSETTA_STORAGE_CLASS', 'rosetta.storage.CacheRosettaStorage')
+
+# Extra locale dirs not used by the current installation
+EXTRA_LOCALE_PATHS = getattr(settings, 'ROSETTA_EXTRA_LOCALE_PATHS', [])

--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -41,6 +41,9 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
     for localepath in settings.LOCALE_PATHS:
         if os.path.isdir(localepath):
             paths.append(localepath)
+    for localepath in rosetta_settings.EXTRA_LOCALE_PATHS:
+        if os.path.isdir(localepath):
+            paths.append(localepath)
 
     # project/app/locale
     for appname in settings.INSTALLED_APPS:

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -331,7 +331,10 @@ list_languages = user_passes_test(lambda user: can_translate(user), settings.LOG
 
 
 def get_app_name(path):
-    app = path.split("/locale")[0].split("/")[-1]
+    if '/locale/' in path:
+        app = path.split("/locale")[0].split("/")[-1]
+    else:
+        app = path.rsplit('/')[-4]
     return app
 
 


### PR DESCRIPTION
Simple future: allow Rosetta to translate po files which are not used for the currently running django instance.

Example use: multiple sites on the software, but with different po-collections for separate sites.
