### PR TITLE
Fix admin images path

### DIFF
--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -231,7 +231,7 @@ def home(request):
                 page_range = range(1, 1 + paginator.num_pages)
         try:
             ADMIN_MEDIA_PREFIX = settings.ADMIN_MEDIA_PREFIX
-            ADMIN_IMAGE_DIR = ADMIN_MEDIA_PREFIX + 'img/admin/'
+            ADMIN_IMAGE_DIR = ADMIN_MEDIA_PREFIX + 'img/'
         except AttributeError:
             ADMIN_MEDIA_PREFIX = settings.STATIC_URL + 'admin/'
             ADMIN_IMAGE_DIR = ADMIN_MEDIA_PREFIX + 'img/'


### PR DESCRIPTION
When settings.ADMIN_MEDIA_PREFIX is set the url is wrongly build. It should only add img to the path.
