### PR TITLE
Fix for projects using Django 1.4 layout

### DIFF
--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -47,10 +47,10 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
     abs_project_path = os.path.normpath(os.path.abspath(os.path.dirname(project.__file__)))
     if project_apps:
         # for Django <= 1.3 project layouts
-        if os.path.exists(os.path.abspath(os.path.join(os.path.dirname(project.__file__), 'manage.py')))
+        if os.path.exists(os.path.abspath(os.path.join(os.path.dirname(project.__file__), 'manage.py'))):
             paths.append(os.path.abspath(os.path.join(os.path.dirname(project.__file__), 'locale')))
         # for Django > 1.4 project layouts
-        elif os.path.exists(os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(project.__file__)), 'manage.py')))
+        elif os.path.exists(os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(project.__file__)), 'manage.py'))):
             paths.append(os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(project.__file__)), 'locale')))
 
     # django/locale

--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -46,7 +46,12 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
     project = __import__(parts[0], {}, {}, [])
     abs_project_path = os.path.normpath(os.path.abspath(os.path.dirname(project.__file__)))
     if project_apps:
-        paths.append(os.path.abspath(os.path.join(os.path.dirname(project.__file__), 'locale')))
+        # for Django <= 1.3 project layouts
+        if os.path.exists(os.path.abspath(os.path.join(os.path.dirname(project.__file__), 'manage.py')))
+            paths.append(os.path.abspath(os.path.join(os.path.dirname(project.__file__), 'locale')))
+        # for Django > 1.4 project layouts
+        elif os.path.exists(os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(project.__file__)), 'manage.py')))
+            paths.append(os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(project.__file__)), 'locale')))
 
     # django/locale
     if django_apps:
@@ -59,6 +64,7 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
                     continue
             cache.set('rosetta_django_paths', django_paths, 60 * 60)
         paths = paths + django_paths
+
     # settings
     for localepath in settings.LOCALE_PATHS:
         if os.path.isdir(localepath):


### PR DESCRIPTION
This pull request fixes [an issue](https://github.com/mbi/django-rosetta/issues/63) where locale directories one dir down from core app directory are ignored even though they are in the actual project root for Django 1.4 project layouts.

https://docs.djangoproject.com/en/dev/releases/1.4/#updated-default-project-layout-and-manage-py

Should work but feel free to suggest cleanups.
