### PR TITLE
fixed mess with app_id between pages

### DIFF
--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -113,7 +113,7 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
                 filename = os.path.join(dirname, fn)
                 if os.path.isfile(filename):
                     ret.add(os.path.abspath(filename))
-    return list(ret)
+    return list(sorted(ret))
 
 
 def pagination_range(first, last, current):


### PR DESCRIPTION
Because of using set for temporal storage for application's po files' pathes in find_pos function, there is a mismatch of po files for the app_id, when moving from the rosetta admin first page to application's translations. Using of "sorted" fixes the problem
