### PR TITLE
Accept languages as 'fr_FR.utf8' in lang_sel url

### DIFF
--- a/rosetta/tests/__init__.py
+++ b/rosetta/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, resolve
 from django.template.defaultfilters import floatformat
 from django.test import TestCase
 from django.test.client import Client
@@ -537,3 +537,8 @@ class RosettaTestCase(TestCase):
         r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
         r = self.client.get(reverse('rosetta-home'))
         self.assertTrue('Progress: 25.00%' in str(r.content))
+
+    def test_24_urlconf_accept_dots_and_underscores(self):
+        resolver_match = resolve("/rosetta/select/fr_FR.utf8/0/")
+        self.assertEqual(resolver_match.url_name, "rosetta-language-selection")
+        self.assertEqual(resolver_match.kwargs['langid'], 'fr_FR.utf8')

--- a/rosetta/urls.py
+++ b/rosetta/urls.py
@@ -8,5 +8,5 @@ urlpatterns = patterns('rosetta.views',
     url(r'^$', 'home', name='rosetta-home'),
     url(r'^pick/$', 'list_languages', name='rosetta-pick-file'),
     url(r'^download/$', 'download_file', name='rosetta-download-file'),
-    url(r'^select/(?P<langid>[\w\-]+)/(?P<idx>\d+)/$', 'lang_sel', name='rosetta-language-selection'),
+    url(r'^select/(?P<langid>[\w\-_\.]+)/(?P<idx>\d+)/$', 'lang_sel', name='rosetta-language-selection'),
 )


### PR DESCRIPTION
I have modified the urlconf to allow language codes with dots and underscores (as in fr_FR.utf8)
