### PR TITLE
Implement ROSETTA_CACHE_NAME, which defaults to 'rosetta' with …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,9 @@ Rosetta can be configured via the following parameters, to be defined in your pr
 * ``ROSETTA_EXCLUDED_APPLICATIONS``: Exclude applications defined in this list from being translated. Defaults to ``()``.
 * ``ROSETTA_REQUIRES_AUTH``: Require authentication for all Rosetta views. Defaults to ``True``.
 * ``ROSETTA_POFILE_WRAP_WIDTH``: Sets the line-length of the edited PO file. Set this to ``0`` to mimic ``makemessage``'s ``--no-wrap`` option. Defaults to ``78``.
-* ``ROSETTA_STORAGE_CLASS``: See the note below on Storages. Defaults to ``rosetta.storage.CacheRosettaStorage``
+* ``ROSETTA_STORAGE_CLASS``: See the note below on Storages. Defaults to ``rosetta.storage.CacheRosettaStorage``.
 * ``ROSETTA_ACCESS_CONTROL_FUNCTION``: An alternative function that determines if a given user can access the translation views. This function receives a ``user`` as its argument, and returns a boolean specifying whether the passed user is allowed to use Rosetta or not.
+* ``ROSETTA_CACHE_NAME``: When using ``rosetta.storage.CacheRosettaStorage``, you can store the rosetta data in a specific cache. This is particularly useful when your ``default`` cache is a ``django.core.cache.backends.dummy.DummyCache`` (which happens on pre-production environments). If unset, it will default to ``rosetta`` if a cache with this name exists, or ``default`` if not.
 
 ********
 Storages
@@ -71,7 +72,7 @@ To prevent re-reading and parsing the PO file catalogs over and over again, Rose
 
 Django 1.4 has introduced a signed cookie session backend, which stores the whole content of the session in an encrypted cookie. Unfortunately this doesn't work with large PO files, as the limit of 4096 chars that can be stored in a cookie are easily exceeded. 
 
-In this case the Cache-based backend should be used (by setting ``ROSETTA_STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'``). Please make sure that a proper CACHES backend is configured in your Django settings.
+In this case the Cache-based backend should be used (by setting ``ROSETTA_STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'``). Please make sure that a proper CACHES backend is configured in your Django settings. You can specify an alternate cache name in ``ROSETTA_CACHE_NAME`` if for some reasons your don't want Rosetta to populate your ``default`` cache.
 
 Alternatively you can switch back to using the Session based storage by setting ``ROSETTA_STORAGE_CLASS = 'rosetta.storage.SessionRosettaStorage`` in your settings. This is perfectly safe on Django 1.3. On Django 1.4 or higher make sure you have DON'T use the `signed_cookies <https://docs.djangoproject.com/en/dev/topics/http/sessions/#using-cookie-based-sessions>`_ ``SESSION_BACKEND`` with this Rosetta storage backend or funky things might happen.
 

--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -54,3 +54,7 @@ POFILE_WRAP_WIDTH = getattr(settings, 'ROSETTA_POFILE_WRAP_WIDTH', 78)
 
 # Storage class to handle temporary data storage
 STORAGE_CLASS = getattr(settings, 'ROSETTA_STORAGE_CLASS', 'rosetta.storage.CacheRosettaStorage')
+
+ROSETTA_CACHE_NAME = getattr(settings, 'ROSETTA_CACHE_NAME', 'default'
+                             if settings.CACHES.get('rosetta', None) is None
+                             else 'rosetta')

--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import get_cache
 from rosetta.conf import settings as rosetta_settings
 import django
 import os
-import six
+
 try:
     from django.utils import timezone
 except:
@@ -15,6 +15,8 @@ try:
     set
 except NameError:
     from sets import Set as set   # Python 2.3 fallback
+
+cache = get_cache(rosetta_settings.ROSETTA_CACHE_NAME)
 
 
 def timestamp_with_timezone(dt=None):

--- a/rosetta/storage.py
+++ b/rosetta/storage.py
@@ -1,10 +1,14 @@
-from django.core.cache import cache
+from django.core.cache import get_cache
 from django.conf import settings
 from django.utils import importlib
 from django.core.exceptions import ImproperlyConfigured
+from rosetta.conf import settings as rosetta_settings
 import hashlib
 import time
 import six
+
+
+cache = get_cache(rosetta_settings.ROSETTA_CACHE_NAME)
 
 
 class BaseRosettaStorage(object):
@@ -70,7 +74,7 @@ class CacheRosettaStorage(BaseRosettaStorage):
             raise ImproperlyConfigured("You can't use the CacheRosettaStorage because your Django Session storage doesn't seem to be working. The CacheRosettaStorage relies on the Django Session storage to avoid conflicts.")
 
         # Make sure we're not using DummyCache
-        if 'dummycache' in settings.CACHES['default']['BACKEND'].lower():
+        if 'dummycache' in settings.CACHES[rosetta_settings.ROSETTA_CACHE_NAME]['BACKEND'].lower():
             raise ImproperlyConfigured("You can't use the CacheRosettaStorage if your cache isn't correctly set up (you are use the DummyCache cache backend).")
 
         # Make sure the actually actually works


### PR DESCRIPTION
...a fallback to 'default' if unset.

Hi,

In my environments I need the dummycache on the development/test side to avoid cache display issues, and I don't intend at all to provide rosetta on production environments on which I don't want to mess with git merges, etc.

I thus hacked rosetta to be able to use a dedicated cache, if present in the django settings. It will automatically use the `rosetta` cache if defined. But for more complex setups the app will lookup a new setting which defines the cache name.

On default and simple installs, it can simply stay unset and the app will happily use the `default` cache. 

Your current tests against dummycache remain completely valid and will test the final destination to avoid typos / other human config errors.

In the patch there are also small flake8 happyness modification, like unused imports removed or "line too long" wrapped. Nevertheless, I didn't alter the whole project to fix flake8 suggestions everywhere. Just drop me a note I you would like me to.

Hope this patch will make it in rosetta mainline. Best regards,
## 

Olivier
