### PR TITLE
added stats by symbols on 'list_languages' page

### DIFF
--- a/rosetta/polib.py
+++ b/rosetta/polib.py
@@ -623,6 +623,32 @@ class POFile(_BaseFile):
         translated = len(self.translated_entries())
         return int((100.00 / float(total)) * translated)
 
+    def all_symbols_count(self):
+        """
+        Convenience method that returns count of symbols in all messages
+        """
+        return sum(len(e.msgid) for e in self if not e.obsolete)
+
+    def symbols_translated(self):
+        """
+        Convenience method that returns count of symbols in translated messages
+        """
+        return sum(len(e.msgid) for e in self.translated_entries())
+
+    def symbols_percents(self):
+        """
+        Convenience method that returns the percentage of translated symbols
+        """
+        if self.all_symbols_count() == 0:
+            return 100
+        return float(self.symbols_translated())/self.all_symbols_count()*100
+
+    def symbols_in_translations(self):
+        """
+        Convenience method that returns count of symbols in translations
+        """
+        return sum(len(e.msgstr) for e in self.translated_entries())
+
     def translated_entries(self):
         """
         Convenience method that returns the list of translated entries.

--- a/rosetta/templates/rosetta/languages.html
+++ b/rosetta/templates/rosetta/languages.html
@@ -29,13 +29,22 @@
             <table cellspacing="0">
                 <thead>
                     <tr>
-                        <th>{% trans "Application" %}</th>
+                        <th rowspan="2">{% trans "Application" %}</th>
+                        <th colspan="3" style="text-align: center;">{% trans "Stats by messages" %}</th>
+                        <th colspan="4" style="text-align: center;">{% trans "Stats by symbols" %}</th>
+                        <th rowspan="2" class="r">{% trans "Fuzzy"%}</th>
+                        <th rowspan="2" class="r">{% trans "Obsolete"%}</th>
+                        <th rowspan="2">{% trans "File" %}</th>
+                    </tr>
+                    <tr>
                         <th class="r">{% trans "Progress"%}</th>
                         <th class="r">{% trans "Messages" %}</th>
                         <th class="r">{% trans "Translated" %}</th>
-                        <th class="r">{% trans "Fuzzy"%}</th>
-                        <th class="r">{% trans "Obsolete"%}</th>
-                        <th>{% trans "File" %}</th>
+
+                        <th class="r">{% trans "Progress" %}</th>
+                        <th class="r">{% trans "Symbols" %}</th>
+                        <th class="r">{% trans "Translated symbols" %}</th>
+                        <th class="r">{% trans "Symbols in translations" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -47,6 +56,12 @@
                         <td class="ch-messages r">{{po.translated_entries|length|add:len_untranslated_entries}}</td>
                         {% endwith %}
                         <td class="ch-translated r">{{po.translated_entries|length}}</td>
+
+                        <td class="ch-symbols-progress r">{{po.symbols_percents|floatformat:2}}%</td>
+                        <td class="ch-symbols-all r">{{po.all_symbols_count}}</td>
+                        <td class="ch-symbols-translated r">{{po.symbols_translated}}</td>
+                        <td class="ch-symbols-in-translations r">{{po.symbols_in_translations}}</td>
+
                         <td class="ch-fuzzy r">{{po.fuzzy_entries|length}}</td>
                         <td class="ch-obsolete r">{{po.obsolete_entries|length}}</td>
                         <td class="hint">{{ path }}</td>


### PR DESCRIPTION
In our company we needed statistics by symbols to measure translators work. So, I changed first page a bit to show how many symbols in messages, translated symbols, symbols in translations and overall progress by symbols
