### PR TITLE
Language-specific translator groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Rosetta can be configured via the following parameters, to be defined in your pr
 * ``ROSETTA_POFILE_WRAP_WIDTH``: Sets the line-length of the edited PO file. Set this to ``0`` to mimic ``makemessage``'s ``--no-wrap`` option. Defaults to ``78``.
 * ``ROSETTA_STORAGE_CLASS``: See the note below on Storages. Defaults to ``rosetta.storage.CacheRosettaStorage``
 * ``ROSETTA_ACCESS_CONTROL_FUNCTION``: An alternative function that determines if a given user can access the translation views. This function receives a ``user`` as its argument, and returns a boolean specifying whether the passed user is allowed to use Rosetta or not.
+* ``ROSETTA_LANGUAGE_GROUPS``: Set to ``True`` to enable language-specific groups, which can be used to give different translators access to different languages.
 * ``ROSETTA_CACHE_NAME``: When using ``rosetta.storage.CacheRosettaStorage``, you can store the rosetta data in a specific cache. This is particularly useful when your ``default`` cache is a ``django.core.cache.backends.dummy.DummyCache`` (which happens on pre-production environments). If unset, it will default to ``rosetta`` if a cache with this name exists, or ``default`` if not.
 * ``ROSETTA_POFILENAMES``: Defines which po filenames are exposed in the web interface. Defaults to ``('django.po', 'djangojs.po')``
 

--- a/rosetta/access.py
+++ b/rosetta/access.py
@@ -6,6 +6,21 @@ def can_translate(user):
     return get_access_control_function()(user)
 
 
+def can_translate_language(user, langid):
+    
+    use_language_groups = getattr(settings, 'ROSETTA_LANGUAGE_GROUPS', False)
+    
+    if not use_language_groups:
+        return can_translate(user)
+    elif not user.is_authenticated():
+        return False
+    elif user.is_superuser and user.is_staff:
+        return True
+    else:
+        return user.groups.filter(name='translators-%s' % langid).exists()
+        
+
+
 def get_access_control_function():
     """
     Return a predicate for determining if a user can access the Rosetta views

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -16,7 +16,7 @@ from polib import pofile
 from rosetta.poutil import find_pos, pagination_range, timestamp_with_timezone
 from rosetta.signals import entry_changed, post_save
 from rosetta.storage import get_storage
-from rosetta.access import can_translate
+from rosetta.access import can_translate, can_translate_language
 
 import json
 import re
@@ -337,6 +337,9 @@ def list_languages(request, do_session_warn=False):
 
     has_pos = False
     for language in settings.LANGUAGES:
+        if not can_translate_language(request.user, language[0]):
+            continue
+        
         pos = find_pos(language[0], project_apps=project_apps, django_apps=django_apps, third_party_apps=third_party_apps)
         has_pos = has_pos or len(pos)
         languages.append(
@@ -373,7 +376,7 @@ def lang_sel(request, langid, idx):
     Selects a file to be translated
     """
     storage = get_storage(request)
-    if langid not in [l[0] for l in settings.LANGUAGES]:
+    if langid not in [l[0] for l in settings.LANGUAGES] or not can_translate_language(request.user, langid):
         raise Http404
     else:
 


### PR DESCRIPTION
Hi,

I have tried to add a new option that allows you to create language-specific groups of translators.

If you add this to your settings:

``` python
ROSETTA_LANGUAGE_GROUPS = True
```

Adding users to a `translators` group will give them access to Rosetta, but not to any actual languages – the list will be empty. For each language, that you have, you need to create a similarly named group `translators-XX` for XX being the language identifier (e.g. `fr`, `fr_FR` or `fr_FR.utf8`). Then you can add each translator to the group(s), that they need access to.

Staff users will have access to all languages regardless of groups.

I have not created a test for this (there didn't seem to be a test for the basic translators group to start from), but can probably do so if it pleases the crowd.
