### PR TITLE
Allow filter-out some translatable strings

### DIFF
--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -81,3 +81,7 @@ ROSETTA_EXCLUDED_PATHS =  getattr(settings, 'ROSETTA_EXCLUDED_PATHS', ())
 # 'translators` group, create individual per-language groups, e.g.
 # 'translators-de', 'translators-fr', ...
 ROSETTA_LANGUAGE_GROUPS = getattr(settings, 'ROSETTA_LANGUAGE_GROUPS', False)
+
+# Custom filter to filter-out some strings
+# Set to function accepting request and list of PO file lines
+TRANSLATIONS_FILTER = getattr(settings, 'ROSETTA_TRANSLATIONS_FILTER', None)

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -194,16 +194,21 @@ def home(request):
         if 'query' in request.REQUEST and request.REQUEST.get('query', '').strip():
             query = request.REQUEST.get('query').strip()
             rx = re.compile(re.escape(query), re.IGNORECASE)
-            paginator = Paginator([e for e in rosetta_i18n_pofile if not e.obsolete and rx.search(six.text_type(e.msgstr) + six.text_type(e.msgid) + u''.join([o[0] for o in e.occurrences]))], rosetta_settings.MESSAGES_PER_PAGE)
+            strings = [e for e in rosetta_i18n_pofile if not e.obsolete and rx.search(six.text_type(e.msgstr) + six.text_type(e.msgid) + u''.join([o[0] for o in e.occurrences]))]
         else:
             if rosetta_i18n_filter == 'untranslated':
-                paginator = Paginator(rosetta_i18n_pofile.untranslated_entries(), rosetta_settings.MESSAGES_PER_PAGE)
+                strings = rosetta_i18n_pofile.untranslated_entries()
             elif rosetta_i18n_filter == 'translated':
-                paginator = Paginator(rosetta_i18n_pofile.translated_entries(), rosetta_settings.MESSAGES_PER_PAGE)
+                strings = rosetta_i18n_pofile.translated_entries()
             elif rosetta_i18n_filter == 'fuzzy':
-                paginator = Paginator([e for e in rosetta_i18n_pofile.fuzzy_entries() if not e.obsolete], rosetta_settings.MESSAGES_PER_PAGE)
+                strings = [e for e in rosetta_i18n_pofile.fuzzy_entries() if not e.obsolete]
             else:
-                paginator = Paginator([e for e in rosetta_i18n_pofile if not e.obsolete], rosetta_settings.MESSAGES_PER_PAGE)
+                strings = [e for e in rosetta_i18n_pofile if not e.obsolete]
+
+        if rosetta_settings.TRANSLATIONS_FILTER:
+            strings = rosetta_settings.TRANSLATIONS_FILTER(request, strings)
+
+        paginator = Paginator(strings, rosetta_settings.MESSAGES_PER_PAGE)
 
         if 'page' in request.GET and int(request.GET.get('page')) <= paginator.num_pages and int(request.GET.get('page')) > 0:
             page = int(request.GET.get('page'))


### PR DESCRIPTION
Translators that use rosetta interface should not see some internal strings. This hook allows us to skip some strings based on logged-in user. But there are definitely more possible use-cases for this feature.
