### PR TITLE
Attempt to fix lookup for django AppConfig

### DIFF
--- a/rosetta/poutil.py
+++ b/rosetta/poutil.py
@@ -88,7 +88,7 @@ def find_pos(lang, project_apps=True, django_apps=False, third_party_apps=False)
         # module.
         if django.VERSION[0:2] >= (1,7):
             if inspect.isclass(app) and issubclass(app, AppConfig):
-                app = apps.get_app_config(app.name).module
+                app = apps.get_containing_app_config(app.name).module
 
         try:
             if issubclass(app, AppConfig):


### PR DESCRIPTION
I faced a lookup error on my apps that use dot paths:

for instance, `mycompany.myapp` is known as `myapp` in `apps.get_app_config`, even if `app.name` is `mycompany.myapp`.

Using `apps.get_containing_app_config` lets django find the proper app.

(This is clearly not tested on enough cases to be sure of the impacts)
