### PR TITLE
Allow more recent polib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'six >=1.2.0',
         'Django >= 1.3',
         'requests >= 2.1.0',
-        'polib == 1.0.4',
+        'polib >= 1.0.4',
         'microsofttranslator == 0.5'
     ]
 )


### PR DESCRIPTION
There were several useful fixes in polib > 1.0.4

I don't know exactly what to restrict.
It might be a better idea to do >= 1.0.4, < 1.1
