### PR TITLE
Include testproject

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ recursive-include rosetta/locale *
 recursive-include rosetta/tests *
 recursive-include rosetta/utils *
 recursive-include rosetta/templates *
-prune testproject
+recursive-include testproject *
 prune rosetta/tests/__pycache__
 prune rosetta/utils/__pycache__
 prune rosetta/utils/microsofttranslator/__pycache__

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email='mbonetti@gmail.com',
     url='https://github.com/mbi/django-rosetta',
     license='MIT',
-    packages=find_packages(),
+    packages=find_packages(exclude=['testproject', 'testproject.*']),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
It would be nice to have the testproject included in the `sdist` tarball. This would, for instance, enable the Debian package to run the tests during build time.
