### PR TITLE
Add support for PEP 3101 (Advanced String Formatting)

### DIFF
--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -89,7 +89,7 @@ google.setOnLoadCallback(function() {
     $('.translation textarea').blur(function() {
         if($(this).val()) {
             $('.alert', $(this).parents('tr')).remove();
-            var RX = /%(?:\([^\s\)]*\))?[sdf]/g,
+            var RX = /%(?:\([^\s\)]*\))?[sdf]|\{[\w\d_]+?\}/g,
                 origs=$('.original', $(this).parents('tr')).html().match(RX),
                 trads=$(this).val().match(RX),
                 error = $('<span class="alert">Unmatched variables</span>');

--- a/rosetta/templatetags/rosetta.py
+++ b/rosetta/templatetags/rosetta.py
@@ -7,7 +7,7 @@ import six
 
 
 register = template.Library()
-rx = re.compile(r'(%(\([^\s\)]*\))?[sd])')
+rx = re.compile(r'(%(\([^\s\)]*\))?[sd]|\{[\w\d_]+?\})')
 
 
 def format_message(message):


### PR DESCRIPTION
Rosetta currently highlights and and does some matching of Python's % based string formatting.

Since version 0.18.3 gettext has supported Python's new .format() based string formatting as defined in PEP 3101. This pull request updates Rosetta's existing regular expressions to also match this new type of formatting.
