### PR TITLE
Search image in Django 1.9.1

### DIFF
--- a/rosetta/templates/rosetta/languages.html
+++ b/rosetta/templates/rosetta/languages.html
@@ -13,9 +13,6 @@
     <ul class="object-tools">
         <li class="nobubble">{% trans "Filter" %}:</li>
         <li{% ifequal rosetta_i18n_catalog_filter 'project' %} class="active"{% endifequal %}><a href="?filter=project">{% trans "Project" %}</a></li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'third-party' %} class="active"{% endifequal %}><a href="?filter=third-party">{% trans "Third party" %}</a></li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'django' %} class="active"{% endifequal %}><a href="?filter=django">Django</a></li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'all' %} class="active"{% endifequal %}><a href="?filter=all">{% trans "All" %}</a></li>
     </ul>
 
     {% if has_pos %}

--- a/rosetta/templates/rosetta/pofile.html
+++ b/rosetta/templates/rosetta/pofile.html
@@ -48,8 +48,13 @@
         <div id="toolbar">
             <form id="changelist-search" action="" method="post">
                 <div>
+                    {% static "admin/img/icon_searchbox.png" as searchbox %}
+                    {% if use_new_admin_images %}
+                      {% static "admin/img/search.svg" as searchbox %}
+                    {% endif %}
+
                     {% rosetta_csrf_token %}
-                    <label for="searchbar"><img src="{% static "admin/img/icon_searchbox.png" %}" alt="{% trans "Search" %}" /></label>
+                    <label for="searchbar"><img src="{{searchbox}}" alt="{% trans "Search" %}" /></label>
                     <input type="text" size="40" name="query" value="{% if query %}{{query}}{% endif %}" id="searchbar" tabindex="0" />
                     <input type="submit" name="search" value="{% trans "Go" %}" />
                 </div>
@@ -57,7 +62,7 @@
         </div>
 
         <form method="post" action="">
-            {% rosetta_csrf_token %}          
+            {% rosetta_csrf_token %}
             <table>
                 <thead>
                     <tr>

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.core.paginator import Paginator
@@ -277,7 +278,8 @@ def home(request):
             page=page,
             query=query,
             paginator=paginator,
-            rosetta_i18n_pofile=rosetta_i18n_pofile
+            rosetta_i18n_pofile=rosetta_i18n_pofile,
+            use_new_admin_images=django.get_version() in ['1.9.1']
         ), context_instance=RequestContext(request))
     else:
         return list_languages(request, do_session_warn=True)


### PR DESCRIPTION
The old search image removed in django 1.9.1, so use the new one if the django version is 1.9.1.
If the user has an older django then everything stay the same.
