### PR TITLE
Use language code without country specification for Yandex dest lang

### DIFF
--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -46,13 +46,15 @@ google.setOnLoadCallback(function() {
         var orig = $('.original .message', a.parents('tr')).html();
         var trans=$('textarea',a.parent());
         var apiUrl = "https://translate.yandex.net/api/v1.5/tr.json/translate";
+        var destLangRoot = '{{ rosetta_i18n_lang_code }}'.split('-')[0];
+        var lang = '{{ rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE }}-' + destLangRoot;
 
         a.attr('class','suggesting').html('...');
 
         var apiData = {
             error: 'onTranslationError',
             success: 'onTranslationComplete',
-            lang: '{{ rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE }}-{{ rosetta_i18n_lang_code }}',
+            lang: lang,
             key: '{{ rosetta_settings.YANDEX_TRANSLATE_KEY }}',
             format: 'html',
             text: orig


### PR DESCRIPTION
The Yandex translation service supports translations into [various languages using two-letter language codes](https://tech.yandex.com/translate/doc/dg/concepts/langs-docpage/).

The API format for specifying the source and destination language is `xx-yy` where `xx` is the source language two-letter code and `yy` is the destination language two-letter code.

If Rosetta is translating a language with a language code that has a county specifier, e.g. `pt-br` (Brazilian Portuguese), the string that is passed to the API includes the country specifier. In this case it would be `en-pt-br` for translation from English.

This causes the API request to fail with a 501 API response:

`{"code":501,"message":"The specified translation direction is not supported"}`

This PR trims any country specifier so that just the two-letter destination language code is sent. In this case it would result in `en-pt` being sent, with the English being translated into Portuguese.
