### PR TITLE
Fix an invalid page get parameter by falling back to page 1

### DIFF
--- a/rosetta/tests/tests.py
+++ b/rosetta/tests/tests.py
@@ -726,6 +726,18 @@ class RosettaTestCase(TestCase):
         r = self.client.get(reverse('rosetta-pick-file'))
         self.assertTrue(os.path.normpath('locale/zh_Hans/LC_MESSAGES/django.po') in str(r.content))
 
+    def test_39_invalid_get_page(self):
+        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
+        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
+        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
+
+        r = self.client.get(reverse('rosetta-home'))
+        self.assertEqual(r.context['page'], 1)
+        r = self.client.get(reverse('rosetta-home') + '?page=')
+        self.assertEqual(r.context['page'], 1)
+        r = self.client.get(reverse('rosetta-home') + '?page=%s' % 'x')
+        self.assertEqual(r.context['page'], 1)
+
 
 # Stubbed access control function
 def no_access(user):

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -213,10 +213,15 @@ def home(request):
             else:
                 paginator = Paginator([e_ for e_ in rosetta_i18n_pofile if not e_.obsolete], rosetta_settings.MESSAGES_PER_PAGE)
 
-        if 'page' in request.GET and int(request.GET.get('page')) <= paginator.num_pages and int(request.GET.get('page')) > 0:
-            page = int(request.GET.get('page'))
-        else:
-            page = 1
+        page = 1
+        if 'page' in request.GET:
+            try:
+                get_page = int(request.GET.get('page'))
+            except ValueError:
+                page = 1  # fall back to page 1
+            else:
+                if 0 < get_page <= paginator.num_pages:
+                    page = get_page
 
         if '_next' in request.GET or '_next' in request.POST:
             page += 1


### PR DESCRIPTION
### All Submissions:
- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [x] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

Updated docs not applicable.

Fixes a minor bug when then url contains a missing/non-integer page number for pagination.
