### PR TITLE
Fix IndexError in fix_nls when translation is just a carriage return

### DIFF
--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -50,7 +50,9 @@ def home(request):
             out_ = "\n" + out_
         elif "\n" != in_[0] and "\n" == out_[0]:
             out_ = out_.lstrip()
-        if "\n" == in_[-1] and "\n" != out_[-1]:
+        if 0 == len(out_):
+            pass
+        elif "\n" == in_[-1] and "\n" != out_[-1]:
             out_ = out_ + "\n"
         elif "\n" != in_[-1] and "\n" == out_[-1]:
             out_ = out_.rstrip()


### PR DESCRIPTION
### All Submissions:
- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

"string index out of range" occurs with a non-empty source string
where the user has (probably erroneously) entered a carriage return
in the translated string, e.g. `fix_nls('x', '\r\n')`

Looks like an edge case initially, but was triggered by a real user accidentally adding a carriage return but not entering a translation.

After line 52, if out_ started out as "\r\n" it will now be an empty string, causing the [-1] indexing to fail. The change skips those clauses and returns the empty string (thus 'fixing' the bare carriage return which is more likely to be accidental than intended).

No existing unit test for fix_nls and this seemed too minor to add a new one just for this specific case, however there are no regressions in the tests.
