### PR TITLE
Remove 2dp float formatting of integer percent translated

### DIFF
--- a/rosetta/templates/rosetta/languages.html
+++ b/rosetta/templates/rosetta/languages.html
@@ -41,7 +41,7 @@
                     {% for app,path,po in pos %}
                     <tr class="{% cycle 'row1' 'row2' %}">
                         <td><a href="{% url 'rosetta-language-selection' lid forloop.counter0 %}{% if do_django %}?django{% endif %}{% if do_rosetta %}?rosetta{% endif %}">{{ app|title }}</a></td>
-                        <td class="ch-progress r">{{po.percent_translated|floatformat:2}}%</td>
+                        <td class="ch-progress r">{{po.percent_translated}}%</td>
                         {% with po.untranslated_entries|length as len_untranslated_entries %}
                         <td class="ch-messages r">{{po.translated_entries|length|add:len_untranslated_entries}}</td>
                         {% endwith %}

--- a/rosetta/templates/rosetta/pofile.html
+++ b/rosetta/templates/rosetta/pofile.html
@@ -14,14 +14,14 @@
 
 {% endblock %}
 
-{% block pagetitle %}{{block.super}} - {{rosetta_settings.MESSAGES_SOURCE_LANGUAGE_NAME}} - {{rosetta_i18n_lang_name}} ({{ rosetta_i18n_pofile.percent_translated|floatformat:0 }}%){% endblock %}
+{% block pagetitle %}{{block.super}} - {{rosetta_settings.MESSAGES_SOURCE_LANGUAGE_NAME}} - {{rosetta_i18n_lang_name}} ({{ rosetta_i18n_pofile.percent_translated }}%){% endblock %}
 
 {% block breadcumbs %}
     <div>
         <a href="{% url 'rosetta-pick-file' %}">{% trans "Home" %}</a> &rsaquo;
         {{ rosetta_i18n_lang_name }} &rsaquo;
         {{ rosetta_i18n_app|title }} &rsaquo;
-        {% blocktrans with rosetta_i18n_pofile.percent_translated|floatformat:2 as percent_translated  %}Progress: {{ percent_translated }}%{% endblocktrans %}
+        {% blocktrans with rosetta_i18n_pofile.percent_translated as percent_translated  %}Progress: {{ percent_translated }}%{% endblocktrans %}
     </div>
     {% if not rosetta_i18n_write %}<p class="errornote read-only">{% trans "File is read-only: download the file when done editing!" %}</p>{% endif %}
     {% if rosetta_last_save_error %}<p class="errornote save-conflict">{% trans "Some items in your last translation block couldn't be saved: this usually happens when the catalog file changes on disk after you last loaded it." %}</p>{% endif %}

--- a/rosetta/tests/tests.py
+++ b/rosetta/tests/tests.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse, resolve
 from django.core.exceptions import ImproperlyConfigured
 from django.core.cache import cache
-from django.template.defaultfilters import floatformat
 from django.test import TestCase  # , override_settings
 from django.test.client import Client
 from django.dispatch import receiver
@@ -272,7 +271,7 @@ class RosettaTestCase(TestCase):
         r = self.client.get(reverse('rosetta-pick-file'))
 
         self.assertTrue('<td class="ch-messages r">1</td>' in str(r.content))
-        self.assertTrue('<td class="ch-progress r">%s%%</td>' % str(floatformat(0.0, 2)) in str(r.content))
+        self.assertTrue('<td class="ch-progress r">0%</td>' in str(r.content))
         self.assertTrue('<td class="ch-obsolete r">1</td>' in str(r.content))
 
     def test_11_issue_80_tab_indexes(self):
@@ -553,10 +552,10 @@ class RosettaTestCase(TestCase):
         r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
         r = self.client.get(reverse('rosetta-home'))
 
-        self.assertTrue('Progress: 0.00%' in str(r.content))
+        self.assertTrue('Progress: 0%' in str(r.content))
         r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
         r = self.client.get(reverse('rosetta-home'))
-        self.assertTrue('Progress: 25.00%' in str(r.content))
+        self.assertTrue('Progress: 25%' in str(r.content))
 
     def test_25_replace_access_control(self):
         # Test default access control allows access


### PR DESCRIPTION
### All Submissions:
- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [x] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

pofile.percent_translated [returns an int](https://bitbucket.org/izi/polib/src/e57eb8e2a29473ce2263b349c8fa6c414565bd53/polib.py?fileviewer=file-view-default#polib.py-648) so the floatformat:2 filter
only ever renders as X.00, so tidier just to show X% rather than X.00%

A minor frontend tweak so as not to tease about the accuracy of completion, certainly not essential :)
