### PR TITLE
Rosetta at admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ testproject/src/
 testproject/.coverage
 .tox
 .eggs
-
+.idea

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -20,6 +20,7 @@ Rosetta can be configured via the following parameters, to be defined in your pr
 * ``ROSETTA_EXCLUDED_PATHS``: Exclude paths defined in this list from being searched (usually ends with "locale"). Defaults to ``()``
 * ``ROSETTA_AUTO_COMPILE``: Determines whether the MO file is automatically compiled when the PO file is saved. Defaults to ``True``.
 * ``ROSETTA_ENABLE_REFLANG``: Enables a selector for picking a reference language other than English. Defaults to ``False``.
+* ``ROSETTA_SHOW_AT_ADMIN_PANEL``: Enable rosetta at administration panel (NOTE: rosetta need to be first at INSTALLED_APPS). Defaults to ``False``.
 
 Storages
 --------

--- a/rosetta/__init__.py
+++ b/rosetta/__init__.py
@@ -1,4 +1,5 @@
 VERSION = (0, 7, 13)
+default_app_config = "rosetta.apps.RosettaAppConfig"
 
 
 def get_version(svn=False, limit=3):

--- a/rosetta/apps.py
+++ b/rosetta/apps.py
@@ -28,7 +28,7 @@ class RosettaAppConfig(AppConfig):
                         },
                     ],
                     'has_module_perms': True,
-                    'name': _('Transplations'),
+                    'name': _('Translations'),
                     'app_label': 'rosetta'
                 }
                 resp.context_data['app_list'].append(app_dict)

--- a/rosetta/apps.py
+++ b/rosetta/apps.py
@@ -1,0 +1,40 @@
+from django.apps import AppConfig
+from django.views.decorators.cache import never_cache
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+
+from rosetta.conf import settings as rosetta_settings
+
+
+class RosettaAppConfig(AppConfig):
+    name = 'rosetta'
+
+    def ready(self):
+        from django.contrib import admin
+        from django.contrib.admin import sites
+
+        class RosettaAdminSite(admin.AdminSite):
+            @never_cache
+            def index(self, request, extra_context=None):
+                resp = super(RosettaAdminSite, self).index(request,
+                                                           extra_context)
+                app_dict = {
+                    'app_url': reverse('rosetta-home'),
+                    'models': [
+                        {
+                            'admin_url': reverse('rosetta-home'),
+                            'name': _('Browse'),
+                            'add_url': None
+                        },
+                    ],
+                    'has_module_perms': True,
+                    'name': _('Transplations'),
+                    'app_label': 'rosetta'
+                }
+                resp.context_data['app_list'].append(app_dict)
+                return resp
+
+        if rosetta_settings.SHOW_AT_ADMIN_PANEL:
+            rosetta = RosettaAdminSite()
+            admin.site = rosetta
+            sites.site = rosetta

--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -86,3 +86,5 @@ ROSETTA_LANGUAGE_GROUPS = getattr(settings, 'ROSETTA_LANGUAGE_GROUPS', False)
 
 # Determines whether the MO file is automatically compiled when the PO file is saved.
 AUTO_COMPILE = getattr(settings, 'ROSETTA_AUTO_COMPILE', True)
+
+SHOW_AT_ADMIN_PANEL = getattr(settings, 'SHOW_AT_ADMIN_PANEL', False)

--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -87,4 +87,4 @@ ROSETTA_LANGUAGE_GROUPS = getattr(settings, 'ROSETTA_LANGUAGE_GROUPS', False)
 # Determines whether the MO file is automatically compiled when the PO file is saved.
 AUTO_COMPILE = getattr(settings, 'ROSETTA_AUTO_COMPILE', True)
 
-SHOW_AT_ADMIN_PANEL = getattr(settings, 'SHOW_AT_ADMIN_PANEL', False)
+SHOW_AT_ADMIN_PANEL = getattr(settings, 'ROSETTA_SHOW_AT_ADMIN_PANEL', False)


### PR DESCRIPTION
For enable rosetta ad admin panel we need:
1. Add ROSETTA_SHOW_AT_ADMIN_PANEL = True to settings.py
2. Rosetta need to be first at INSTALLED_APPS

