### PR TITLE
The reference language didn't work in widows

### DIFF
--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -222,7 +222,9 @@ def home(request):
             ref_lang = storage.get('rosetta_i18n_ref_lang_code', 'msgid')
             ref_pofile = None
             if ref_lang != 'msgid':
-                ref_fn = re.sub('/locale/[a-z]{2}/', '/locale/%s/' % ref_lang, rosetta_i18n_fn)
+                replacement = '{separator}locale{separator}{ref_lang}'.format(separator=os.sep, ref_lang=ref_lang)
+                pattern = '\{separator}locale\{separator}[a-z]{{2}}'.format(separator=os.sep)
+                ref_fn = re.sub(pattern, replacement, rosetta_i18n_fn)
                 try:
                     ref_pofile = pofile(ref_fn)
                 except IOError:


### PR DESCRIPTION
Inside the home view when the setting ENABLE_REFLANG is enabled and the reference language is different from the default rosseta didn't change it. This only happend in Windows due to the pattern '/locale/[a-z]{2}/' and the replacement string '/locale/%s/' % ref_lang. Windows file paths do not use '/' and therefore the re.sub never returned the path of the file we tried to generate.
Poposed solution: We create two new variables pattern and replacement that depend on the OS. These two new variables are used in re.sub.