### PR TITLE
Rewrite urls to be RESTful & views to be class-based & less cache-heavy

### DIFF
--- a/rosetta/templates/rosetta/admin_index.html
+++ b/rosetta/templates/rosetta/admin_index.html
@@ -7,11 +7,11 @@
     <div class="app-rosetta module">
         <table>
         <caption>
-            <a class="section" href="{% url 'rosetta-home' %}">Rosetta</a>
+            <a class="section" href="{% url 'rosetta-file-list' po_filter='project' %}">Rosetta</a>
         </caption>
             <tbody><tr>
-                <th scope="row"><a href="{% url 'rosetta-home' %}">{% trans "Translations" %}</a></th>
-                <td colspan="2"><a href="{% url 'rosetta-home' %}" class="changelink">{% trans "Change" %}</a></td>
+                <th scope="row"><a href="{% url 'rosetta-file-list' po_filter='project' %}">{% trans "Translations" %}</a></th>
+                <td colspan="2"><a href="{% url 'rosetta-file-list' po_filter='project' %}" class="changelink">{% trans "Change" %}</a></td>
             </tr>
         </tbody></table>
     </div>

--- a/rosetta/templates/rosetta/base.html
+++ b/rosetta/templates/rosetta/base.html
@@ -24,7 +24,7 @@
         <div id="header">
             {% block header %}
             <div id="branding">
-                <h1 id="site-name"><a href="{% url 'rosetta-pick-file' %}">Rosetta</a> </h1>
+                <h1 id="site-name"><a href="{% url 'rosetta-file-list' po_filter='project' %}">Rosetta</a> </h1>
             </div>
             {% endblock %}
         </div>

--- a/rosetta/templates/rosetta/file-list.html
+++ b/rosetta/templates/rosetta/file-list.html
@@ -4,7 +4,7 @@
 {% block pagetitle %}{{block.super}} - {% trans "Language selection" %}{% endblock %}
 
 {% block breadcumbs %}
-    <div><a href="{% url 'rosetta-pick-file' %}">{% trans "Home" %}</a> &rsaquo; {% trans "Language selection" %}</div>
+    <div><a href="{% url 'rosetta-file-list' po_filter=po_filter %}">{% trans "Home" %}</a> &rsaquo; {% trans "Language selection" %}</div>
     {% if do_session_warn %}<p class="errornote session-warn">{% trans "Couldn't load the specified language file. This usually happens when using the Encrypted Cookies Session Storage backend on Django 1.4 or higher.<br/>Setting ROSETTA_STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage' in your settings file should fix this." %}</p>{% endif %}
 {% endblock %}
 
@@ -12,10 +12,10 @@
     <h1>&nbsp;</h1>
     <ul class="object-tools">
         <li class="nobubble">{% trans "Filter" %}:</li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'project' %} class="active"{% endifequal %}><a href="?filter=project">{% trans "Project" %}</a></li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'third-party' %} class="active"{% endifequal %}><a href="?filter=third-party">{% trans "Third party" %}</a></li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'django' %} class="active"{% endifequal %}><a href="?filter=django">Django</a></li>
-        <li{% ifequal rosetta_i18n_catalog_filter 'all' %} class="active"{% endifequal %}><a href="?filter=all">{% trans "All" %}</a></li>
+        <li{% ifequal po_filter 'project' %} class="active"{% endifequal %}><a href="{% url 'rosetta-file-list' po_filter='project' %}">{% trans "Project" %}</a></li>
+        <li{% ifequal po_filter 'third-party' %} class="active"{% endifequal %}><a href="{% url 'rosetta-file-list' po_filter='third-party' %}">{% trans "Third party" %}</a></li>
+        <li{% ifequal po_filter 'django' %} class="active"{% endifequal %}><a href="{% url 'rosetta-file-list' po_filter='django' %}">Django</a></li>
+        <li{% ifequal po_filter 'all' %} class="active"{% endifequal %}><a href="{% url 'rosetta-file-list' po_filter='all' %}">{% trans "All" %}</a></li>
     </ul>
 
     {% if has_pos %}
@@ -40,7 +40,7 @@
                 <tbody>
                     {% for app,path,po in pos %}
                     <tr class="{% cycle 'row1' 'row2' %}">
-                        <td><a href="{% url 'rosetta-language-selection' lid forloop.counter0 %}">{{ app|title }}</a></td>
+                        <td><a href="{% url 'rosetta-form' po_filter=po_filter lang_id=lid idx=forloop.counter0 %}">{{ app|title }}</a></td>
                         <td class="ch-progress r">{{po.percent_translated}}%</td>
                         {% with po.untranslated_entries|length as len_untranslated_entries %}
                         <td class="ch-messages r">{{po.translated_entries|length|add:len_untranslated_entries}}</td>

--- a/rosetta/templates/rosetta/form.html
+++ b/rosetta/templates/rosetta/form.html
@@ -5,8 +5,8 @@
     {{block.super}}
     <div id="user-tools">
         <p>
-            <span><a href="{% url 'rosetta-pick-file' %}">{% trans "Pick another file" %}</a> /
-            <a href="{% url 'rosetta-download-file' %}">{% trans "Download this catalog" %}</a></span>
+            <span><a href="{% url 'rosetta-file-list' po_filter=po_filter %}">{% trans "Pick another file" %}</a> /
+            <a href="{% url 'rosetta-download-file' po_filter=po_filter lang_id=lang_id idx=idx %}">{% trans "Download this catalog" %}</a></span>
         </p>
     </div>
     <script type="text/javascript">
@@ -18,13 +18,12 @@
 
 {% block breadcumbs %}
     <div>
-        <a href="{% url 'rosetta-pick-file' %}">{% trans "Home" %}</a> &rsaquo;
+        <a href="{% url 'rosetta-file-list' po_filter=po_filter %}">{% trans "Home" %}</a> &rsaquo;
         {{ rosetta_i18n_lang_name }} &rsaquo;
         {{ rosetta_i18n_app|title }} &rsaquo;
         {% blocktrans with rosetta_i18n_pofile.percent_translated as percent_translated  %}Progress: {{ percent_translated }}%{% endblocktrans %}
     </div>
     {% if not rosetta_i18n_write %}<p class="errornote read-only">{% trans "File is read-only: download the file when done editing!" %}</p>{% endif %}
-    {% if rosetta_last_save_error %}<p class="errornote save-conflict">{% trans "Some items in your last translation block couldn't be saved: this usually happens when the catalog file changes on disk after you last loaded it." %}</p>{% endif %}
     {% if messages %}
         <div class="messages errornote save-conflict">
         {% for message in messages %}
@@ -39,31 +38,30 @@
 
     <ul class="object-tools">
         <li class="nobubble">{% trans "Display:" %}</li>
-        <li {% if rosetta_i18n_filter == 'untranslated' %}class="active"{% endif %}><a href="?filter=untranslated">{% trans "Untranslated only" %}</a></li>
-        <li {% if rosetta_i18n_filter == 'translated' %}class="active"{% endif %}><a href="?filter=translated">{% trans "Translated only" %}</a></li>
-        <li {% if rosetta_i18n_filter == 'fuzzy' %}class="active"{% endif %}><a href="?filter=fuzzy">{% trans "Fuzzy only" %}</a></li>
-        <li {% if rosetta_i18n_filter == 'all' %}class="active"{% endif %}><a href="?filter=all">{% trans "All" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'untranslated' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=untranslated">{% trans "Untranslated only" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'translated' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=translated">{% trans "Translated only" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'fuzzy' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=fuzzy">{% trans "Fuzzy only" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'all' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=all">{% trans "All" %}</a></li>
     </ul>
     <div id="changelist" class="module{% if rosetta_i18n_lang_bidi %} rtl{% endif %}">
 
 
         <div id="toolbar">
-            <form id="changelist-search" action="" method="post">
+            <form id="changelist-search" action="" method="get">
                 <div>
-                    {% rosetta_csrf_token %}
                     <label for="searchbar"><img src="{% static "admin/img/icon_searchbox_rosetta.png" %}" alt="{% trans "Search" %}" /></label>
-                    <input type="text" size="40" name="query" value="{% if query %}{{query}}{% endif %}" id="searchbar" tabindex="0" />
-                    <input type="submit" name="search" value="{% trans "Go" %}" />
+                    <input type="text" size="40" name="query" value="{{query}}" id="searchbar" tabindex="0" />
+                    <input type="submit" name="s" value="{% trans "Go" %}" />
                 </div>
             </form>
         </div>
 
-        {% if ENABLE_REFLANG %}
+        {% if rosetta_settings.ENABLE_REFLANG %}
         <div class="actions">
             <label for="ref-language-selector">{% trans "Reference language" %}:</label>
             <select class="select-across" id="ref-language-selector" onchange="javascript:window.location.href = this.value;">
                 {% for langid, langname in LANGUAGES %}
-                    <option{% ifequal ref_lang langid %} selected="selected"{% endifequal %} value="{% url 'rosetta-reference-selection' langid=langid %}">{{langname}}</option>
+                    <option{% ifequal ref_lang langid %} selected="selected"{% endifequal %} value="?ref_lang={{ langid }}">{{langname}}</option>
                 {% endfor %}
             </select>
         </div>
@@ -108,7 +106,7 @@
                             </td>
                         {% else %}
                             <td class="original">
-                                {% if ENABLE_REFLANG %}
+                                {% if rosetta_settings.ENABLE_REFLANG %}
                                 <span class="message">{{ message.ref_txt|format_message|linebreaksbr }}</span>
                                 {% else %}
                                 <span class="message">{{ message.msgid|format_message|linebreaksbr }}</span>
@@ -159,7 +157,7 @@
                         {% if i == page %}
                             <span class="this-page">{{i}}</span>
                         {% else %}
-                            <a href="?page={{i}}{% if query %}&amp;query={{query}}{% endif %}">{{i}}</a>
+                            <a href="?{{ pagination_query_string_base }}&page={{i}}">{{i}}</a>
                         {% endif %}
                         {% endif %}
                     {% endfor %}

--- a/rosetta/tests/django.po.test44.template
+++ b/rosetta/tests/django.po.test44.template
@@ -1,0 +1,170 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+msgid ""
+msgstr ""
+"Project-Id-Version: Rosetta\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-10-21 12:21+0200\n"
+"PO-Revision-Date: 2008-09-22 11:02\n"
+"Last-Translator: Admin Admin <admin@admin.com>\n"
+"Language-Team: French <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Translated-Using: django-rosetta 0.4.RC2\n"
+
+
+msgid "String 1"
+msgstr ""
+
+msgid "String 2"
+msgstr ""
+
+msgid "String 3"
+msgstr ""
+
+msgid "String 4"
+msgstr ""
+
+msgid "String 5"
+msgstr ""
+
+msgid "String 6"
+msgstr ""
+
+msgid "String 7"
+msgstr ""
+
+msgid "String 8"
+msgstr ""
+
+msgid "String 9"
+msgstr ""
+
+msgid "String 10"
+msgstr ""
+
+msgid "String 11"
+msgstr ""
+
+msgid "String 12"
+msgstr ""
+
+msgid "String 13"
+msgstr ""
+
+msgid "String 14"
+msgstr ""
+
+msgid "String 15"
+msgstr ""
+
+msgid "String 16"
+msgstr ""
+
+msgid "String 17"
+msgstr ""
+
+msgid "String 18"
+msgstr ""
+
+msgid "String 19"
+msgstr ""
+
+msgid "String 20"
+msgstr ""
+
+msgid "String 21"
+msgstr ""
+
+msgid "String 22"
+msgstr ""
+
+msgid "String 23"
+msgstr ""
+
+msgid "String 24"
+msgstr ""
+
+msgid "String 25"
+msgstr ""
+
+msgid "String 26"
+msgstr ""
+
+msgid "String 27"
+msgstr ""
+
+msgid "String 28"
+msgstr ""
+
+msgid "String 29"
+msgstr ""
+
+msgid "String 30"
+msgstr ""
+
+msgid "String 31"
+msgstr ""
+
+msgid "String 32"
+msgstr ""
+
+msgid "String 33"
+msgstr ""
+
+msgid "String 34"
+msgstr ""
+
+msgid "String 35"
+msgstr ""
+
+msgid "String 36"
+msgstr ""
+
+msgid "String 37"
+msgstr ""
+
+msgid "String 38"
+msgstr ""
+
+msgid "String 39"
+msgstr ""
+
+msgid "String 40"
+msgstr ""
+
+msgid "String 41"
+msgstr ""
+
+msgid "String 42"
+msgstr ""
+
+msgid "String 43"
+msgstr ""
+
+msgid "String 44"
+msgstr ""
+
+msgid "String 45"
+msgstr ""
+
+msgid "String 46"
+msgstr ""
+
+msgid "String 47"
+msgstr ""
+
+msgid "String 48"
+msgstr ""
+
+msgid "String 49"
+msgstr ""
+
+#. Translators: consectetur adipisicing
+#: templates/eiusmod/tempor.html:43
+msgid "Lorem ipsum"
+msgstr "dolor sit amet"

--- a/rosetta/tests/tests.py
+++ b/rosetta/tests/tests.py
@@ -1,21 +1,26 @@
 # -*- coding: utf-8 -*-
-import django
-from django.conf import settings
-if django.VERSION < (1, 10):  # NOQA
-    from django.core.urlresolvers import reverse, resolve  # NOQA
-else:  # NOQA
-    from django.urls import reverse, resolve  # NOQA
-from django.core.exceptions import ImproperlyConfigured
-from django.core.cache import cache
-from django.test import TestCase
-from django.test.client import Client
-from django.dispatch import receiver
-from rosetta.conf import settings as rosetta_settings
-from rosetta.signals import entry_changed, post_save
+import filecmp
+import hashlib
 import os
 import shutil
+
+from django.conf import settings
+from django.dispatch import receiver
+try:
+    from django.urls import reverse, resolve
+except ImportError:
+    from django.core.urlresolvers import reverse, resolve
+from django.core.exceptions import ImproperlyConfigured
+from django.http import Http404
+from django.test import TestCase, RequestFactory
+from django.test.client import Client
+from django import VERSION
 import six
-import hashlib
+
+from rosetta.conf import settings as rosetta_settings
+from rosetta.signals import entry_changed, post_save
+from rosetta.storage import get_storage
+from rosetta import views
 
 
 class RosettaTestCase(TestCase):
@@ -23,8 +28,9 @@ class RosettaTestCase(TestCase):
     def __init__(self, *args, **kwargs):
         super(RosettaTestCase, self).__init__(*args, **kwargs)
         self.curdir = os.path.dirname(__file__)
-        self.dest_file = os.path.normpath(os.path.join(self.curdir, '../locale/xx/LC_MESSAGES/django.po'))
-
+        self.dest_file = os.path.normpath(
+            os.path.join(self.curdir, '../locale/xx/LC_MESSAGES/django.po')
+            )
 
     def setUp(self):
         from django.contrib.auth.models import User
@@ -40,6 +46,7 @@ class RosettaTestCase(TestCase):
         user2.save()
         user3.save()
 
+        self.user = user
         self.client2 = Client()
 
         self.client.login(username='test_admin', password='test_password')
@@ -74,35 +81,47 @@ class RosettaTestCase(TestCase):
 
         shutil.move(self.dest_file + '.orig', self.dest_file)
 
+    def copy_po_file_from_template(self, template_path):
+        """Utility method to handle swapping a template po file in place for
+        testing.
+        """
+        src_path = os.path.normpath(os.path.join(self.curdir, template_path))
+        shutil.copy(src_path, self.dest_file)
+
+    @property
+    def xx_form_url(self):
+        kwargs = {'po_filter': 'third-party', 'lang_id': 'xx', 'idx': 0}
+        return reverse('rosetta-form', kwargs=kwargs)
+
+    @property
+    def third_party_file_list_url(self):
+        return reverse('rosetta-file-list', kwargs={'po_filter': 'third-party'})
+
     def test_1_ListLoading(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertTrue(
+            os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content)
+            )
 
     def test_2_PickFile(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0,), kwargs=dict()) + '?rosetta')
-        r = self.client.get(reverse('rosetta-home'))
-
+        r = self.client.get(self.xx_form_url)
         self.assertTrue('dummy language' in str(r.content))
 
     def test_3_DownloadZIP(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()) + '?rosetta')
-        r = self.client.get(reverse('rosetta-home'))
-        r = self.client.get(reverse('rosetta-download-file') + '?rosetta')
+        kwargs = {'po_filter': 'third-party', 'lang_id': 'xx', 'idx': 0}
+        url = reverse('rosetta-download-file', kwargs=kwargs)
+        r = self.client.get(url)
         self.assertTrue('content-type' in r._headers.keys())
         self.assertTrue('application/x-zip' in r._headers.get('content-type'))
 
     def test_4_DoChanges(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
+        self.copy_po_file_from_template('./django.po.template')
+        untranslated_url = self.xx_form_url + '?msg_filter=untranslated'
+        translated_url = self.xx_form_url + '?msg_filter=translated'
 
         # Load the template file
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(untranslated_url)
+
         # make sure both strings are untranslated
         self.assertTrue('dummy language' in str(r.content))
         self.assertTrue('String 1' in str(r.content))
@@ -110,43 +129,36 @@ class RosettaTestCase(TestCase):
         self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        r = self.client.post(untranslated_url, data, follow=True)
 
         # reload all untranslated strings
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()) + '?rosetta')
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(untranslated_url)
 
         # the translated string no longer is up for translation
         self.assertTrue('String 1' in str(r.content))
         self.assertTrue('String 2' not in str(r.content))
 
         # display only translated strings
-        r = self.client.get(reverse('rosetta-home') + '?filter=translated')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(translated_url)
 
-        # The tranlsation was persisted
+        # The translation was persisted
         self.assertTrue('String 1' not in str(r.content))
         self.assertTrue('String 2' in str(r.content))
         self.assertTrue('Hello, world' in str(r.content))
 
     def test_5_TestIssue67(self):
-        # testcase for issue 67: http://code.google.com/p/django-rosetta/issues/detail?id=67
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue67.template')), self.dest_file)
+        # issue 67: http://code.google.com/p/django-rosetta/issues/detail?id=67
+        self.copy_po_file_from_template('./django.po.issue67.template')
+
         # Make sure the plurals string is valid
-        f_ = open(self.dest_file, 'rb')
-        content = f_.read()
-        f_.close()
+        with open(self.dest_file, 'rb') as f_:
+            content = f_.read()
         self.assertTrue('Hello, world' not in six.text_type(content))
         self.assertTrue('|| n%100>=20) ? 1 : 2)' in six.text_type(content))
         del(content)
 
-        # Load the template file
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()) + '?rosetta')
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url + '?msg_filter=untranslated')
 
         # make sure all strings are untranslated
         self.assertTrue('dummy language' in str(r.content))
@@ -155,97 +167,90 @@ class RosettaTestCase(TestCase):
         self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        self.client.post(self.xx_form_url + '?msg_filter=untranslated', data)
 
         # Make sure the plurals string is still valid
-        f_ = open(self.dest_file, 'rb')
-        content = f_.read()
-        f_.close()
+        with open(self.dest_file, 'rb') as f_:
+            content = f_.read()
         self.assertTrue('Hello, world' in str(content))
         self.assertTrue('|| n%100>=20) ? 1 : 2)' in str(content))
         self.assertTrue('or n%100>=20) ? 1 : 2)' not in str(content))
         del(content)
 
     def test_6_ExcludedApps(self):
-
         rosetta_settings.EXCLUDED_APPLICATIONS = ('rosetta',)
-
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue('rosetta/locale/xx/LC_MESSAGES/django.po' not in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertNotContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
         rosetta_settings.EXCLUDED_APPLICATIONS = ()
-
-        r = self.client.get(reverse('rosetta-pick-file') + '?rosetta')
-        self.assertTrue('rosetta/locale/xx/LC_MESSAGES/django.po' in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
     def test_7_selfInApplist(self):
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue('rosetta/locale/xx/LC_MESSAGES/django.po' in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
-        self.client.get(reverse('rosetta-pick-file') + '?filter=project')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue('rosetta/locale/xx/LC_MESSAGES/django.po' not in str(r.content))
+        url = reverse('rosetta-file-list', kwargs={'po_filter': 'project'})
+        r = self.client.get(url)
+        self.assertNotContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
     def test_8_hideObsoletes(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
+        r = self.client.get(self.xx_form_url)
 
         # not in listing
         for p in range(1, 5):
-            r = self.client.get(reverse('rosetta-home') + '?page=%d' % p)
+            r = self.client.get(self.xx_form_url + '?page=%d' % p)
             self.assertTrue('dummy language' in str(r.content))
             self.assertTrue('Les deux' not in str(r.content))
 
-        r = self.client.get(reverse('rosetta-home') + '?query=Les%20Deux')
-        self.assertTrue('dummy language' in str(r.content))
-        self.assertTrue('Les deux' not in str(r.content))
+        r = self.client.get(self.xx_form_url + '?query=Les%20Deux')
+        self.assertContains(r, 'dummy language')
+        self.assertNotContains(r, 'Les deux')
 
     def test_9_concurrency(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
-
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client2.get(reverse('rosetta-pick-file') + '?filter=third-party')
-
-        self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        self.client2.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
+        self.copy_po_file_from_template('./django.po.template')
+        translated_url = self.xx_form_url + '?msg_filter=translated'
+        untranslated_url = self.xx_form_url + '?msg_filter=untranslated'
 
         # Load the template file
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
-        r2 = self.client2.get(reverse('rosetta-home') + '?filter=untranslated')
-        r2 = self.client2.get(reverse('rosetta-home'))
+        r = self.client.get(untranslated_url)
+        r2 = self.client2.get(untranslated_url)
 
-        self.assertTrue('String 1' in str(r.content))
-        self.assertTrue('String 1' in str(r2.content))
-        self.assertTrue('m_08e4e11e2243d764fc45a5a4fba5d0f2' in str(r.content))
-        r = self.client.post(reverse('rosetta-home'), dict(m_08e4e11e2243d764fc45a5a4fba5d0f2='Hello, world', _next='_next'), follow=True)
-        r2 = self.client2.get(reverse('rosetta-home'))
+        self.assertContains(r, 'String 1')
+        self.assertContains(r2, 'String 1')
+        self.assertContains(r, 'm_08e4e11e2243d764fc45a5a4fba5d0f2')
 
-        # Client 2 reloads the home, forces a reload of the catalog,
-        # the untranslated string1 is now translated
-        self.assertTrue('String 1' not in str(r2.content))
-        self.assertTrue('String 2' in str(r2.content))
+        data = {'m_08e4e11e2243d764fc45a5a4fba5d0f2': 'Hello, world'}
+        r = self.client.post(untranslated_url, data, follow=True)
 
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
-        r2 = self.client2.get(reverse('rosetta-home') + '?filter=untranslated')
-        r2 = self.client2.get(reverse('rosetta-home'))
+        # Client 2 reloads, forces a reload of the catalog; untranslated
+        # string1 is now translated
+        r2 = self.client2.get(untranslated_url, follow=True)
+        self.assertNotContains(r, 'String 1')
+        self.assertContains(r, 'String 2')
+        self.assertNotContains(r2, 'String 1')
+        self.assertContains(r2, 'String 2')
 
-        self.assertTrue('String 2' in str(r2.content) and 'm_e48f149a8b2e8baa81b816c0edf93890' in str(r2.content))
-        self.assertTrue('String 2' in str(r.content) and 'm_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
+        r = self.client.get(untranslated_url)
+        r2 = self.client2.get(untranslated_url)
+
+        self.assertContains(r2, 'String 2')
+        self.assertContains(r2, 'm_e48f149a8b2e8baa81b816c0edf93890')
+        self.assertContains(r, 'String 2')
+        self.assertContains(r, 'm_e48f149a8b2e8baa81b816c0edf93890')
 
         # client 2 posts!
-        r2 = self.client2.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world, from client two!', _next='_next'), follow=True)
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world, from client two!'}
+        r2 = self.client2.post(untranslated_url, data, follow=True)
 
-        self.assertTrue('save-conflict' not in str(r2.content))
+        self.assertNotContains(r2, 'save-conflict')
 
         # uh-oh here comes client 1
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world, from client one!', _next='_next'), follow=True)
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world, from client one!'}
+        r = self.client.post(untranslated_url, data, follow=True)
         # An error message is displayed
-        self.assertTrue('save-conflict' in str(r.content))
+        self.assertContains(r, 'save-conflict')
 
         # client 2 won
         with open(self.dest_file, 'r') as po_file:
@@ -253,97 +258,84 @@ class RosettaTestCase(TestCase):
         self.assertTrue('Hello, world, from client two!' in pofile_content)
 
         # Both clients show all strings, error messages are gone
-        r = self.client.get(reverse('rosetta-home') + '?filter=translated')
-        self.assertTrue('save-conflict' not in str(r.content))
-        r2 = self.client2.get(reverse('rosetta-home') + '?filter=translated')
-        self.assertTrue('save-conflict' not in str(r2.content))
-        r = self.client.get(reverse('rosetta-home'))
-        self.assertTrue('save-conflict' not in str(r.content))
-        r2 = self.client2.get(reverse('rosetta-home'))
-        self.assertTrue('save-conflict' not in str(r2.content))
+        r = self.client.get(translated_url)
+        self.assertNotContains(r, 'save-conflict')
+        r2 = self.client2.get(translated_url)
+        self.assertNotContains(r2, 'save-conflict')
+        r = self.client.get(self.xx_form_url)
+        self.assertNotContains(r, 'save-conflict')
+        r2 = self.client2.get(self.xx_form_url)
+        self.assertNotContains(r2, 'save-conflict')
 
         # Both have client's two version
-        self.assertTrue('Hello, world, from client two!' in str(r.content))
-        self.assertTrue('Hello, world, from client two!' in str(r2.content))
-        self.assertTrue('save-conflict' not in str(r2.content))
-        self.assertTrue('save-conflict' not in str(r.content))
-
+        self.assertContains(r, 'Hello, world, from client two!')
+        self.assertContains(r2, 'Hello, world, from client two!')
 
     def test_10_issue_79_num_entries(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue79.template')), self.dest_file)
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-
-        self.assertTrue('<td class="ch-messages r">1</td>' in str(r.content))
-        self.assertTrue('<td class="ch-progress r">0%</td>' in str(r.content))
-        self.assertTrue('<td class="ch-obsolete r">1</td>' in str(r.content))
+        self.copy_po_file_from_template('./django.po.issue79.template')
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, '<td class="ch-messages r">1</td>')
+        self.assertContains(r, '<td class="ch-progress r">0%</td>')
+        self.assertContains(r, '<td class="ch-obsolete r">1</td>')
 
     def test_11_issue_80_tab_indexes(self):
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0,), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url)
         self.assertTrue('tabindex="3"' in str(r.content))
 
     def test_12_issue_82_staff_user(self):
-        settings.ROSETTA_REQUIRES_AUTH = True
-
         self.client3 = Client()
         self.client3.login(username='test_admin3', password='test_password')
 
-        self.client3.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client3.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client3.get(reverse('rosetta-home'))
-        self.assertTrue(not r.content)
+        # When auth is required, we get an empty response (and a redirect) with
+        # this user.
+        settings.ROSETTA_REQUIRES_AUTH = True
+        r = self.client3.get(self.xx_form_url)
+        self.assertFalse(r.content)
+        self.assertEqual(r.status_code, 302)
 
+        # When it's not required, we sail through.
         settings.ROSETTA_REQUIRES_AUTH = False
-
-        self.client3.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client3.get(reverse('rosetta-language-selection', args=('xx', 0,), kwargs=dict()))
-        r = self.client3.get(reverse('rosetta-home'))
-        self.assertFalse(not r.content)
+        r = self.client3.get(self.xx_form_url)
+        self.assertTrue(r.content)
+        self.assertEqual(r.status_code, 200)
 
     def test_13_catalog_filters(self):
         settings.LANGUAGES = (('fr', 'French'), ('xx', 'Dummy Language'),)
-        cache.delete('rosetta_django_paths')
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertTrue(
+            os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content)
+            )
         self.assertTrue(('contrib') not in str(r.content))
 
-        self.client.get(reverse('rosetta-pick-file') + '?filter=django')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') not in str(r.content))
+        url = reverse('rosetta-file-list', kwargs={'po_filter': 'django'})
+        r = self.client.get(url)
+        self.assertTrue(
+            os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') not in str(r.content)
+            )
+        self.assertTrue(('contrib') in str(r.content))
 
-        if django.VERSION[0:2] >= (1, 3):
-            self.assertTrue(('contrib') in str(r.content))
+        url = reverse('rosetta-file-list', kwargs={'po_filter': 'all'})
+        r = self.client.get(url)
+        self.assertTrue(
+            os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content)
+            )
+        self.assertTrue(('contrib') in str(r.content))
 
-        self.client.get(reverse('rosetta-pick-file') + '?filter=all')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
-
-        if django.VERSION[0:2] >= (1, 3):
-            self.assertTrue(('contrib') in str(r.content))
-
-        self.client.get(reverse('rosetta-pick-file') + '?filter=project')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') not in str(r.content))
-        if django.VERSION[0:2] >= (1, 3):
-            self.assertTrue(('contrib') not in str(r.content))
+        url = reverse('rosetta-file-list', kwargs={'po_filter': 'project'})
+        r = self.client.get(url)
+        self.assertTrue(
+            os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') not in str(r.content)
+            )
+        self.assertTrue(('contrib') not in str(r.content))
 
     def test_14_issue_99_context_and_comments(self):
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url)
         self.assertTrue('This is a text of the base template' in str(r.content))
         self.assertTrue('Context hint' in str(r.content))
 
     def test_15_issue_87_entry_changed_signal(self):
-        # copy the template file
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
-
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0,), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        self.copy_po_file_from_template('./django.po.template')
+        r = self.client.get(self.xx_form_url)
 
         @receiver(entry_changed)
         def test_receiver(sender, **kwargs):
@@ -353,7 +345,8 @@ class RosettaTestCase(TestCase):
         self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        self.client.post(self.xx_form_url, data)
 
         self.assertTrue(self.test_old_msgstr == '')
         self.assertTrue(self.test_new_msgstr == 'Hello, world')
@@ -362,10 +355,8 @@ class RosettaTestCase(TestCase):
         del(self.test_old_msgstr, self.test_new_msgstr, self.test_msg_id)
 
     def test_16_issue_101_post_save_signal(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        self.copy_po_file_from_template('./django.po.template')
+        r = self.client.get(self.xx_form_url)
 
         @receiver(post_save)
         def test_receiver(sender, **kwargs):
@@ -374,17 +365,15 @@ class RosettaTestCase(TestCase):
         self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        self.client.post(self.xx_form_url, data)
 
         self.assertTrue(self.test_sig_lang == 'xx')
         del(self.test_sig_lang)
 
     def test_17_issue_103_post_save_signal_has_request(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
-
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        self.copy_po_file_from_template('./django.po.template')
+        r = self.client.get(self.xx_form_url)
 
         @receiver(post_save)
         def test_receiver(sender, **kwargs):
@@ -393,55 +382,58 @@ class RosettaTestCase(TestCase):
         self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        r = self.client.post(self.xx_form_url, data)
 
         self.assertTrue(self.test_16_has_request)
         del(self.test_16_has_request)
-        # reset the original file
 
     def test_18_Test_Issue_gh24(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue24gh.template')), self.dest_file)
-
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        self.copy_po_file_from_template('./django.po.issue24gh.template')
+        r = self.client.get(self.xx_form_url)
 
         self.assertTrue('m_bb9d8fe6159187b9ea494c1b313d23d4' in str(r.content))
 
-        # post a translation, it should have properly wrapped lines
-        r = self.client.post(reverse('rosetta-home'), dict(m_bb9d8fe6159187b9ea494c1b313d23d4='Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.', _next='_next'))
+        # Post a translation, it should have properly wrapped lines
+        data = {'m_bb9d8fe6159187b9ea494c1b313d23d4':
+                'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean '
+                'commodo ligula eget dolor. Aenean massa. Cum sociis natoque '
+                'penatibus et magnis dis parturient montes, nascetur ridiculus '
+                'mus. Donec quam felis, ultricies nec, pellentesque eu, pretium '
+                'quis, sem. Nulla consequat massa quis enim. Donec pede justo, '
+                'fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, '
+                'rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum '
+                'felis eu pede mollis pretium.'}
+        r = self.client.post(self.xx_form_url, data)
         with open(self.dest_file, 'r') as po_file:
             pofile_content = po_file.read()
 
         self.assertTrue('"pede mollis pretium."' in pofile_content)
 
         # Again, with unwrapped lines
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue24gh.template')), self.dest_file)
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
-        self.assertTrue('m_bb9d8fe6159187b9ea494c1b313d23d4' in str(r.content))
+        self.copy_po_file_from_template('./django.po.issue24gh.template')
         rosetta_settings.POFILE_WRAP_WIDTH = 0
-        r = self.client.post(reverse('rosetta-home'), dict(m_bb9d8fe6159187b9ea494c1b313d23d4='Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.', _next='_next'))
+        r = self.client.get(self.xx_form_url)
+        self.assertTrue('m_bb9d8fe6159187b9ea494c1b313d23d4' in str(r.content))
+        r = self.client.post(self.xx_form_url, data)
         with open(self.dest_file, 'r') as po_file:
             pofile_content = po_file.read()
         self.assertTrue('felis eu pede mollis pretium."' in pofile_content)
 
     def test_19_Test_Issue_gh34(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue34gh.template')), self.dest_file)
-
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        self.copy_po_file_from_template('./django.po.issue34gh.template')
+        r = self.client.get(self.xx_form_url)
         self.assertTrue('m_ff7060c1a9aae9c42af4d54ac8551f67_1' in str(r.content))
         self.assertTrue('m_ff7060c1a9aae9c42af4d54ac8551f67_0' in str(r.content))
         self.assertTrue('m_09f7e02f1290be211da707a266f153b3' in str(r.content))
 
         # post a translation, it should have properly wrapped lines
-        r = self.client.post(reverse('rosetta-home'), dict(
-            m_ff7060c1a9aae9c42af4d54ac8551f67_0='Foo %s',
-            m_ff7060c1a9aae9c42af4d54ac8551f67_1='Bar %s',
-            m_09f7e02f1290be211da707a266f153b3='Salut', _next='_next'))
+        data = {
+            'm_ff7060c1a9aae9c42af4d54ac8551f67_0': 'Foo %s',
+            'm_ff7060c1a9aae9c42af4d54ac8551f67_1': 'Bar %s',
+            'm_09f7e02f1290be211da707a266f153b3': 'Salut',
+            }
+        r = self.client.post(self.xx_form_url, data)
         with open(self.dest_file, 'r') as po_file:
             pofile_content = po_file.read()
         self.assertTrue('msgstr "Salut\\n"' in pofile_content)
@@ -449,79 +441,64 @@ class RosettaTestCase(TestCase):
         self.assertTrue('msgstr[1] ""\n"\\n"\n"Bar %s\\n"' in pofile_content)
 
     def test_20_Test_Issue_gh38(self):
-        if django.VERSION[0:2] >= (1, 4):
-            self.assertTrue('django.contrib.sessions.middleware.SessionMiddleware' in settings.MIDDLEWARE_CLASSES)
+        # Set up
+        settings.SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+        # (Have to log in again, since our session engine changed)
+        self.client.login(username='test_admin', password='test_password')
+        self.assertTrue('django.contrib.sessions.middleware.SessionMiddleware'
+                        in settings.MIDDLEWARE_CLASSES)
 
-            settings.SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+        # Only one backend to test: cache backend
+        rosetta_settings.STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'
+        self.copy_po_file_from_template('./django.po.issue38gh.template')
 
-            # One: cache backend
-            rosetta_settings.STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'
+        r = self.client.get(self.xx_form_url)
+        self.assertFalse(len(str(self.client.cookies.get('sessionid'))) > 4096)
+        self.assertTrue('m_9efd113f7919952523f06e0d88da9c54' in str(r.content))
 
-            shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue38gh.template')), self.dest_file)
+        data = {'m_9efd113f7919952523f06e0d88da9c54': 'Testing cookie length'}
+        r = self.client.post(self.xx_form_url, data)
+        with open(self.dest_file, 'r') as po_file:
+            pofile_content = po_file.read()
+        self.assertTrue('Testing cookie length' in pofile_content)
 
-            self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-            self.client.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
-            r = self.client.get(reverse('rosetta-home'))
-            self.assertFalse(len(str(self.client.cookies.get('sessionid'))) > 4096)
-            self.assertTrue('m_9efd113f7919952523f06e0d88da9c54' in str(r.content))
-            r = self.client.post(reverse('rosetta-home'), dict(
-                m_9efd113f7919952523f06e0d88da9c54='Testing cookie length',
-                _next='_next'
-            ))
-            with open(self.dest_file, 'r') as po_file:
-                pofile_content = po_file.read()
-            self.assertTrue('Testing cookie length' in pofile_content)
-
-            self.client.get(reverse('rosetta-home') + '?filter=translated')
-            r = self.client.get(reverse('rosetta-home'))
-            self.assertTrue('Testing cookie length' in str(r.content))
-            self.assertTrue('m_9f6c442c6d579707440ba9dada0fb373' in str(r.content))
-
-            # Two, the cookie backend
-            if django.VERSION[0:2] < (1, 6):
-                rosetta_settings.STORAGE_CLASS = 'rosetta.storage.SessionRosettaStorage'
-
-                shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue38gh.template')), self.dest_file)
-
-                self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-                self.client.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
-                r = self.client.get(reverse('rosetta-home'))
-                self.assertTrue(len(str(self.client.cookies.get('sessionid'))) > 4096)
-                # boom: be a good browser, truncate the cookie
-                self.client.cookies['sessionid'] = six.text_type(self.client.cookies.get('sessionid'))[:4096]
-                r = self.client.get(reverse('rosetta-home'))
-
-                self.assertFalse('m_9efd113f7919952523f06e0d88da9c54' in str(r.content))
+        r = self.client.get(self.xx_form_url + '?filter=translated')
+        self.assertTrue('Testing cookie length' in str(r.content))
+        self.assertTrue('m_9f6c442c6d579707440ba9dada0fb373' in str(r.content))
 
     def test_21_concurrency_of_cache_backend(self):
         rosetta_settings.STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue38gh.template')), self.dest_file)
+        self.copy_po_file_from_template('./django.po.issue38gh.template')
 
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        self.client.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
+        # Force caching into play by making .po file read-only
+        os.chmod(self.dest_file, 292)  # 0444
 
-        self.client2.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        self.client2.get(reverse('rosetta-language-selection', args=('xx', 0, ), kwargs=dict()))
+        self.client.get(self.xx_form_url)
+        self.client2.get(self.xx_form_url)
+        self.assertNotEqual(
+            self.client.session.get('rosetta_cache_storage_key_prefix'),
+            self.client2.session.get('rosetta_cache_storage_key_prefix')
+            )
 
-        self.assertTrue(self.client.session.get('rosetta_cache_storage_key_prefix') != self.client2.session.get('rosetta_cache_storage_key_prefix'))
+        # Clean up (restore perms)
+        os.chmod(self.dest_file, 420)  # 0644
 
     def test_22_Test_Issue_gh39(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue39gh.template')), self.dest_file)
+        self.copy_po_file_from_template('./django.po.issue39gh.template')
 
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url)
         # We have distinct hashes, even though the msgid and msgstr are identical
-        # print (r.content)
         self.assertTrue('m_4765f7de94996d3de5975fa797c3451f' in str(r.content))
         self.assertTrue('m_08e4e11e2243d764fc45a5a4fba5d0f2' in str(r.content))
 
     def test_23_save_header_data(self):
         from django.contrib.auth.models import User
 
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
+        self.copy_po_file_from_template('./django.po.template')
 
-        unicode_user = User.objects.create_user('test_unicode', 'save_header_data@test.com', 'test_unicode')
+        unicode_user = User.objects.create_user(
+            'test_unicode', 'save_header_data@test.com', 'test_unicode'
+            )
         unicode_user.first_name = "aéaéaé aàaàaàa"
         unicode_user.last_name = "aâââ üüüü"
         unicode_user.is_superuser, unicode_user.is_staff = True, True
@@ -530,10 +507,8 @@ class RosettaTestCase(TestCase):
         self.client.login(username='test_unicode', password='test_unicode')
 
         # Load the template file
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url + '?filter=untranslated')
+
         # make sure both strings are untranslated
         self.assertTrue('dummy language' in str(r.content))
         self.assertTrue('String 1' in str(r.content))
@@ -541,34 +516,31 @@ class RosettaTestCase(TestCase):
         self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        r = self.client.post(self.xx_form_url + '?filter=untranslated', data)
         # read the result
-        f_ = open(self.dest_file, 'rb')
-        content = six.text_type(f_.read())
-        f_.close()
-        # print (content)
+        with open(self.dest_file, 'rb') as f_:
+            content = six.text_type(f_.read())
+
         # make sure unicode data was properly converted to ascii
         self.assertTrue('Hello, world' in content)
         self.assertTrue('save_header_data@test.com' in content)
         self.assertTrue('aeaeae aaaaaaa aaaa uuuu' in content)
 
-    def test_24_percent_transaltion(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
+    def test_24_percent_translation(self):
+        self.copy_po_file_from_template('./django.po.template')
 
         # Load the template file
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url)
 
         self.assertTrue('Progress: 0%' in str(r.content))
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
-        r = self.client.get(reverse('rosetta-home'))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        r = self.client.post(self.xx_form_url, data, follow=True)
         self.assertTrue('Progress: 25%' in str(r.content))
 
     def test_25_replace_access_control(self):
         # Test default access control allows access
-        url = reverse('rosetta-home')
+        url = reverse('rosetta-file-list', kwargs={'po_filter': 'project'})
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)
 
@@ -581,81 +553,88 @@ class RosettaTestCase(TestCase):
         settings.ROSETTA_ACCESS_CONTROL_FUNCTION = None
 
     def test_26_urlconf_accept_dots_and_underscores(self):
-        resolver_match = resolve("/rosetta/select/fr_FR.utf8/0/")
-        self.assertEqual(resolver_match.url_name, "rosetta-language-selection")
-        self.assertEqual(resolver_match.kwargs['langid'], 'fr_FR.utf8')
+        resolver_match = resolve('/rosetta/files/all/fr_FR.utf8/0/')
+        self.assertEqual(resolver_match.url_name, 'rosetta-form')
+        self.assertEqual(resolver_match.kwargs['lang_id'], 'fr_FR.utf8')
 
     def test_27_extended_urlconf_language_code_loads_file(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=all')
-        r = self.client.get(reverse('rosetta-language-selection', args=('fr_FR.utf8', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        url = reverse(
+            'rosetta-form',
+            kwargs={'po_filter': 'all', 'lang_id': 'fr_FR.utf8', 'idx': 0}
+            )
+        r = self.client.get(url)
         self.assertTrue('French (France), UTF8' in str(r.content))
         self.assertTrue('m_03a603523bd75b00414a413657acdeb2' in str(r.content))
 
     def test_28_issue_gh87(self):
         """Make sure that rosetta_i18n_catalog_filter is passed into the context."""
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue('<li class="active"><a href="?filter=third-party">' in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, '<li class="active"><a href="/rosetta/files/third-party/">')
 
     def test_29_unsupported_p3_django_16_storage(self):
-        if django.VERSION[0:2] >= (1, 6) and django.VERSION[0:2] < (2, 0):
-            self.assertTrue('django.contrib.sessions.middleware.SessionMiddleware' in settings.MIDDLEWARE_CLASSES)
+        if VERSION[0:2] < (2, 0):
+            self.assertTrue('django.contrib.sessions.middleware.SessionMiddleware'
+                            in settings.MIDDLEWARE_CLASSES)
 
             settings.SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
             rosetta_settings.STORAGE_CLASS = 'rosetta.storage.SessionRosettaStorage'
 
-            try:
-                self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-                self.fail()
-            except ImproperlyConfigured:
-                pass
+            # Force caching to be used by making the pofile read-only
+            os.chmod(self.dest_file, 292)  # 0444
+
+            # (Have to log in again, since our session engine changed)
+            self.client.login(username='test_admin', password='test_password')
+
+            with self.assertRaises(ImproperlyConfigured):
+                self.client.get(self.xx_form_url)
+
+            # Cleanup
+            os.chmod(self.dest_file, 420)  # 0644
 
     def test_30_pofile_names(self):
-        POFILENAMES = rosetta_settings.POFILENAMES
+        ORIG_POFILENAMES = rosetta_settings.POFILENAMES
         rosetta_settings.POFILENAMES = ('pr44.po', )
 
         os.unlink(self.dest_file)
-        destfile = os.path.normpath(os.path.join(self.curdir, '../locale/xx/LC_MESSAGES/pr44.po'))
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './pr44.po.template')), destfile)
+        destfile = os.path.normpath(
+            os.path.join(self.curdir, '../locale/xx/LC_MESSAGES/pr44.po')
+            )
+        shutil.copy(
+            os.path.normpath(os.path.join(self.curdir, './pr44.po.template')),
+            destfile
+            )
 
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.third_party_file_list_url)
         self.assertTrue('xx/LC_MESSAGES/pr44.po' in str(r.content))
 
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0,), kwargs=dict()) + '?rosetta')
-        r = self.client.get(reverse('rosetta-home'))
-
+        r = self.client.get(self.xx_form_url)
         self.assertTrue('dummy language' in str(r.content))
 
+        # (Clean up)
         os.unlink(destfile)
-        rosetta_settings.POFILENAMES = POFILENAMES
-
+        rosetta_settings.POFILENAMES = ORIG_POFILENAMES
 
     def test_31_pr_102__exclude_paths(self):
-        ROSETTA_EXCLUDED_PATHS = rosetta_settings.ROSETTA_EXCLUDED_PATHS
-
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        ORIG_ROSETTA_EXCLUDED_PATHS = rosetta_settings.ROSETTA_EXCLUDED_PATHS
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
         exclude_path = os.path.normpath(os.path.join(self.curdir, '../locale'))
         rosetta_settings.ROSETTA_EXCLUDED_PATHS = [exclude_path, ]
 
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertFalse(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertNotContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
-        rosetta_settings.ROSETTA_EXCLUDED_PATHS = ROSETTA_EXCLUDED_PATHS
+        rosetta_settings.ROSETTA_EXCLUDED_PATHS = ORIG_ROSETTA_EXCLUDED_PATHS
 
     def test_32_pr_103__language_groups(self):
         from django.contrib.auth.models import User, Group
 
-        ROSETTA_LANGUAGE_GROUPS = rosetta_settings.ROSETTA_LANGUAGE_GROUPS
+        ORIG_ROSETTA_LANGUAGE_GROUPS = rosetta_settings.ROSETTA_LANGUAGE_GROUPS
         rosetta_settings.ROSETTA_LANGUAGE_GROUPS = False
 
-        # Default behavior: non admins need to be in a translators group, they see
-        # all catalogs
+        # Default behavior: non-admins need to be in a translators group; they
+        # see all catalogs
         translators = Group.objects.create(name='translators')
         translators_xx = Group.objects.create(name='translators-xx')
 
@@ -666,96 +645,103 @@ class RosettaTestCase(TestCase):
         user4.save()
         self.client.login(username='test_admin4', password='test_password')
 
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
         # Activate the option, user doesn't see the XX catalog
         rosetta_settings.ROSETTA_LANGUAGE_GROUPS = True
 
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertFalse(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertNotContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
         # Now add them to the custom group
         user4.groups.add(translators_xx)
 
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('rosetta/locale/xx/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(self.third_party_file_list_url)
+        self.assertContains(r, 'rosetta/locale/xx/LC_MESSAGES/django.po')
 
-        rosetta_settings.ROSETTA_LANGUAGE_GROUPS = ROSETTA_LANGUAGE_GROUPS
+        # Clean up
+        rosetta_settings.ROSETTA_LANGUAGE_GROUPS = ORIG_ROSETTA_LANGUAGE_GROUPS
 
     def test_33_reflang(self):
-        ENABLE_REFLANG = rosetta_settings.ENABLE_REFLANG
+        ORIG_ENABLE_REFLANG = rosetta_settings.ENABLE_REFLANG
         rosetta_settings.ENABLE_REFLANG = True
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.issue60.template')), self.dest_file)
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home'))
+        self.copy_po_file_from_template('./django.po.issue60.template')
+        r = self.client.get(self.xx_form_url)
 
         # Verify that there's an option to select a reflang
-        self.assertTrue('<option value="/rosetta/select-ref/xx/">dummy language</option>' in str(r.content))
+        self.assertTrue('<option value="?ref_lang=xx">dummy language</option>' in str(r.content))
 
-        r = self.client.get('/rosetta/select-ref/xx/')
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(self.xx_form_url + '?ref_lang=xx')
         # The translated string in the test PO file ends up in the "Reference" column
         self.assertTrue('<span class="message">translated-string1</span>' in str(r.content))
-        rosetta_settings.ENABLE_REFLANG = ENABLE_REFLANG
+        rosetta_settings.ENABLE_REFLANG = ORIG_ENABLE_REFLANG
 
     def test_34_issue_113_app_configs(self):
-        if django.VERSION[0:2] >= (1, 7):
-            r = self.client.get(reverse('rosetta-pick-file') + '?filter=all')
-            r = self.client.get(reverse('rosetta-pick-file'))
-            self.assertTrue('rosetta/select/xx/1/">Test_App' in str(r.content))
+        r = self.client.get(reverse('rosetta-file-list', kwargs={'po_filter': 'all'}))
+        self.assertTrue('rosetta/files/all/xx/1/">Test_App' in str(r.content))
 
     def test_35_issue_135_display_exception_messages(self):
-        shutil.copy(os.path.normpath(os.path.join(self.curdir, './django.po.template')), self.dest_file)
+        # Note: the old version of this test looked for a 'Permission denied'
+        # message reflected in the response. That behavior has now changed so
+        # that changes that can't be persisted through the filesystem .po file
+        # are saved to the cached version of the .po file.
+        self.copy_po_file_from_template('./django.po.template')
+        rosetta_settings.STORAGE_CLASS = 'rosetta.storage.CacheRosettaStorage'
 
-        # Load the template file
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
-        r = self.client.get(reverse('rosetta-home'))
-        # make sure both strings are untranslated
-        self.assertTrue('m_e48f149a8b2e8baa81b816c0edf93890' in str(r.content))
+        r = self.client.get(self.xx_form_url + '?msg_filter=untranslated')
+        self.assertContains(r, 'm_e48f149a8b2e8baa81b816c0edf93890')
 
         # make the pofile read-only
-        os.chmod(self.dest_file, 292)  # 0400
+        os.chmod(self.dest_file, 292)  # 0444
 
         # post a translation
-        r = self.client.post(reverse('rosetta-home'), dict(m_e48f149a8b2e8baa81b816c0edf93890='Hello, world', _next='_next'))
-        r = self.client.get(reverse('rosetta-home'))
-        self.assertTrue(six.text_type('Permission denied') in six.text_type(r.content))
+        data = {'m_e48f149a8b2e8baa81b816c0edf93890': 'Hello, world'}
+        self.client.post(self.xx_form_url, data, follow=True)
+
+        # Confirm that the filesystem file hasn't changed
+        tmpl_path = os.path.normpath(os.path.join(self.curdir, 'django.po.template'))
+        self.assertTrue(filecmp.cmp(tmpl_path, self.dest_file))
+
+        # Confirm that the cached version has been updated
+        cache_key = 'po-file-%s' % self.dest_file
+        request = RequestFactory().get(self.xx_form_url)
+        request.user = self.user
+        request.session = self.client.session
+        storage = get_storage(request)
+
+        po_file = storage.get(cache_key)
+        entry = po_file.find('String 2')
+        self.assertEqual(entry.msgstr, 'Hello, world')
 
         # cleanup
         os.chmod(self.dest_file, 420)  # 0644
 
     def test_36_issue_142_complex_locales(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=all')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('locale/bs-Cyrl-BA/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(reverse('rosetta-file-list', kwargs={'po_filter': 'all'}))
+        self.assertContains(r, 'locale/bs-Cyrl-BA/LC_MESSAGES/django.po')
 
     def test_37_issue_133_complex_locales(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=all')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('locale/yy_Anot/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(reverse('rosetta-file-list', kwargs={'po_filter': 'all'}))
+        self.assertContains(r, 'locale/yy_Anot/LC_MESSAGES/django.po')
 
     def test_38_issue_161_more_weird_locales(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=all')
-        r = self.client.get(reverse('rosetta-pick-file'))
-        self.assertTrue(os.path.normpath('locale/zh_Hans/LC_MESSAGES/django.po') in str(r.content))
+        r = self.client.get(reverse('rosetta-file-list', kwargs={'po_filter': 'all'}))
+        self.assertTrue(r, 'locale/zh_Hans/LC_MESSAGES/django.po')
 
     def test_39_invalid_get_page(self):
-        r = self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        r = self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-        r = self.client.get(reverse('rosetta-home') + '?filter=untranslated')
+        url = self.xx_form_url + '?filter=untranslated'
 
-        r = self.client.get(reverse('rosetta-home'))
+        r = self.client.get(url)   # Page not specified
         self.assertEqual(r.context['page'], 1)
-        r = self.client.get(reverse('rosetta-home') + '?page=')
+
+        r = self.client.get(url + '&page=')  # No number given
         self.assertEqual(r.context['page'], 1)
-        r = self.client.get(reverse('rosetta-home') + '?page=%s' % 'x')
+
+        r = self.client.get(url + '&page=9999')  # Too-high number given
+        self.assertEqual(r.context['page'], 1)
+
+        r = self.client.get(url + '&page=x')  # Non-number given
         self.assertEqual(r.context['page'], 1)
 
     def test_40_issue_155_auto_compile(self):
@@ -770,27 +756,24 @@ class RosettaTestCase(TestCase):
             return hashlib.md5(file_content).hexdigest()
 
         def message_hashes():
-            r = self.client.get(reverse('rosetta-home'))
-            return dict([(m.msgid, 'm_' + m.md5hash) for m in r.context['rosetta_messages']])
+            r = self.client.get(self.xx_form_url)
+            return {m.msgid: 'm_' + m.md5hash for m in r.context['rosetta_messages']}
 
         po_file = self.dest_file
         mo_file = self.dest_file[:-3] + '.mo'
 
-        # Load the template file
-        self.client.get(reverse('rosetta-pick-file') + '?filter=third-party')
-        self.client.get(reverse('rosetta-language-selection', args=('xx', 0), kwargs=dict()))
-
         # MO file will be compiled by default.
-        # Get PO and MO files into an initial reference state (MO will be created or updated)
+        # Get PO and MO files into an initial reference state (MO will be
+        # created or updated)
         msg_hashes = message_hashes()
-        self.client.post(reverse('rosetta-home'), {
-            msg_hashes['String 1']: "Translation 1", '_next': '_next'})
+        data = {msg_hashes['String 1']: 'Translation 1'}
+        self.client.post(self.xx_form_url, data)
         po_file_hash_before, mo_file_hash_before = file_hash(po_file), file_hash(mo_file)
 
         # Make a change to the translations
         msg_hashes = message_hashes()
-        self.client.post(reverse('rosetta-home'), {
-            msg_hashes['String 1']: "Translation 2", '_next': '_next'})
+        data = {msg_hashes['String 1']: 'Translation 2'}
+        self.client.post(self.xx_form_url, data)
 
         # Get the new hashes of the PO and MO file contents
         po_file_hash_after, mo_file_hash_after = file_hash(po_file), file_hash(mo_file)
@@ -805,8 +788,8 @@ class RosettaTestCase(TestCase):
         # Make a change to the translations
         po_file_hash_before, mo_file_hash_before = po_file_hash_after, mo_file_hash_after
         msg_hashes = message_hashes()
-        self.client.post(reverse('rosetta-home'), {
-            msg_hashes['String 1']: "Translation 3", '_next': '_next'})
+        data = {msg_hashes['String 1']: "Translation 3"}
+        self.client.post(self.xx_form_url, data)
         po_file_hash_after, mo_file_hash_after = file_hash(po_file), file_hash(mo_file)
 
         # Only the PO should have changed, the MO should be unchanged
@@ -816,8 +799,8 @@ class RosettaTestCase(TestCase):
         # Verify that translating another string also leaves the MO unchanged
         po_file_hash_before, mo_file_hash_before = po_file_hash_after, mo_file_hash_after
         msg_hashes = message_hashes()
-        self.client.post(reverse('rosetta-home'), {
-            msg_hashes['String 2']: "Translation 4", '_next': '_next'})
+        data = {msg_hashes['String 2']: "Translation 4"}
+        self.client.post(self.xx_form_url, data)
         po_file_hash_after, mo_file_hash_after = file_hash(po_file), file_hash(mo_file)
 
         self.assertNotEqual(po_file_hash_before, po_file_hash_after)
@@ -828,8 +811,8 @@ class RosettaTestCase(TestCase):
 
         po_file_hash_before, mo_file_hash_before = po_file_hash_after, mo_file_hash_after
         msg_hashes = message_hashes()
-        self.client.post(reverse('rosetta-home'), {
-            msg_hashes['String 2']: "Translation 5", '_next': '_next'})
+        data = {msg_hashes['String 2']: "Translation 5"}
+        self.client.post(self.xx_form_url, data)
         po_file_hash_after, mo_file_hash_after = file_hash(po_file), file_hash(mo_file)
 
         self.assertNotEqual(po_file_hash_before, po_file_hash_after)
@@ -837,7 +820,123 @@ class RosettaTestCase(TestCase):
 
     def test_41_pr_176_embed_in_admin(self):
         resp = self.client.get(reverse('admin:index'))
-        self.assertTrue('app-rosetta module' in str(resp.content))
+        self.assertContains(resp, 'app-rosetta module')
+
+    def _setup_view(self, view, request, *args, **kwargs):
+        """Mimic as_view() returned callable, but returns view instance.
+
+        args and kwargs are the same you would pass to ``reverse()``
+        (From http://tech.novapost.fr/django-unit-test-your-views-en.html.)
+        """
+        view.request = request
+        view.args = args
+        view.kwargs = kwargs
+        return view
+
+    def test_42_view_property_po_file_is_writable(self):
+        """Confirm that we're accurately determining the filesystem write-perms
+        on our .po file.
+        """
+        self.copy_po_file_from_template('./django.po.template')
+
+        # By default, we're writable
+        request = RequestFactory().get(self.xx_form_url)
+        request.user = self.user
+        kwargs = {'po_filter': 'third-party', 'lang_id': 'xx', 'idx': 0}
+        view = self._setup_view(
+            view=views.TranslationFormView(),
+            request=request,
+            **kwargs
+            )
+        self.assertTrue(view.po_file_is_writable)
+
+        # Now try again with the file not writable. (Regenerate the view, since
+        # this po_file_is_writable is cached for the life of the request.)
+        # make the pofile read-only
+        os.chmod(self.dest_file, 292)  # 0444
+        view = self._setup_view(
+            view=views.TranslationFormView(),
+            request=request,
+            **kwargs
+            )
+        self.assertFalse(view.po_file_is_writable)
+
+        # Cleanup
+        os.chmod(self.dest_file, 420)  # 0644
+
+    def test_43_view_property_po_file_path(self):
+        """Confirm our class-based views properly parse/validate the path of the
+        .po file in question derived from the url kwargs.
+        """
+        self.copy_po_file_from_template('./django.po.template')
+
+        # By default, when all goes well, we get our existing .po file path
+        request = RequestFactory().get(self.xx_form_url)
+        request.user = self.user
+        kwargs = {'po_filter': 'third-party', 'lang_id': 'xx', 'idx': 0}
+        view = self._setup_view(
+            view=views.TranslationFormView(),
+            request=request,
+            **kwargs
+            )
+        self.assertEqual(view.po_file_path, self.dest_file)
+
+        # But if the language isn't an option, we get a 404
+        ORIG_LANGUAGES = settings.LANGUAGES
+        settings.LANGUAGES = [l for l in settings.LANGUAGES if l[0] != 'xx']
+        view = self._setup_view(
+            view=views.TranslationFormView(),
+            request=request,
+            **kwargs
+            )
+        with self.assertRaises(Http404):
+            view.po_file_path
+
+        settings.LANGUAGES = ORIG_LANGUAGES  # (Clean up)
+
+        # And if the index doesn't correspond with a file, we get a 404
+        new_kwargs = {'po_filter': 'third-party', 'lang_id': 'xx', 'idx': 9}
+        view = self._setup_view(
+            view=views.TranslationFormView(),
+            # Recycle request, even though url kwargs conflict with ones below.
+            request=request,
+            **new_kwargs
+            )
+        with self.assertRaises(Http404):
+            view.po_file_path
+
+    def test_44_message_search_function(self):
+        """Confirm that search of the .po file works across the various message
+        fields.
+        """
+        self.copy_po_file_from_template('./django.po.test44.template')
+        url = self.xx_form_url + '?query=%s'
+
+        # Here's the message entry we're considering:
+        # #. Translators: consectetur adipisicing
+        # #: templates/eiusmod/tempor.html:43
+        # msgid "Lorem ipsum"
+        # msgstr "dolor sit amet"
+        # It is buried at the end of the file, so without searching for it, it
+        # shouldn't be on the page
+        r = self.client.get(url % '')
+        self.assertNotContains(r, 'Lorem')
+
+        # Search msgid
+        r = self.client.get(url % 'ipsum')
+        self.assertContains(r, 'Lorem')
+
+        # Search msgstr
+        r = self.client.get(url % 'dolor')
+        self.assertContains(r, 'Lorem')
+
+        # Search occurences
+        r = self.client.get(url % 'tempor')
+        self.assertContains(r, 'Lorem')
+
+        # Search comments
+        r = self.client.get(url % 'adipisicing')
+        self.assertContains(r, 'Lorem')
 
 
 # Stubbed access control function

--- a/rosetta/urls.py
+++ b/rosetta/urls.py
@@ -1,11 +1,45 @@
 from django.conf.urls import url
-from .views import (home, list_languages, download_file, lang_sel, translate_text, ref_sel)
+from django.views.generic.base import RedirectView
+try:
+    from django.urls import reverse_lazy
+except ImportError:
+    from django.core.urlresolvers import reverse_lazy
+
+from . import views
+
 
 urlpatterns = [
-    url(r'^$', home, name='rosetta-home'),
-    url(r'^pick/$', list_languages, name='rosetta-pick-file'),
-    url(r'^download/$', download_file, name='rosetta-download-file'),
-    url(r'^select/(?P<langid>[\w\-_\.]+)/(?P<idx>\d+)/$', lang_sel, name='rosetta-language-selection'),
-    url(r'^select-ref/(?P<langid>[\w\-_\.]+)/$', ref_sel, name='rosetta-reference-selection'),
-    url(r'^translate/$', translate_text, name='translate_text'),
+
+    url(r'^$',
+        RedirectView.as_view(url=reverse_lazy('rosetta-file-list',
+                                              kwargs={'po_filter': 'project'})),
+        name='rosetta-old-home-redirect',
+        ),
+
+    url(r'^files/$',
+        RedirectView.as_view(url=reverse_lazy('rosetta-file-list',
+                                              kwargs={'po_filter': 'project'})),
+        name='rosetta-file-list-redirect',
+        ),
+
+    url(r'^files/(?P<po_filter>[\w-]+)/$',
+        views.TranslationFileListView.as_view(),
+        name='rosetta-file-list',
+        ),
+
+    url(r'^files/(?P<po_filter>[\w-]+)/(?P<lang_id>[\w\-_\.]+)/(?P<idx>\d+)/$',
+        views.TranslationFormView.as_view(),
+        name='rosetta-form',
+        ),
+
+    url(r'^files/(?P<po_filter>[\w-]+)/(?P<lang_id>[\w\-_\.]+)/(?P<idx>\d+)/download/$',
+        views.TranslationFileDownload.as_view(),
+        name='rosetta-download-file',
+        ),
+
+    url(r'^translate/$',
+        views.translate_text,
+        name='translate_text',
+        ),
+
 ]

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -1,46 +1,262 @@
-import django
+import hashlib
+import json
+import os
+import os.path
+import re
+try:
+    # Python 3
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2
+    from urllib import urlencode
+import zipfile
+
 from django.conf import settings
-from django.contrib.auth.decorators import user_passes_test
-from django.core.paginator import Paginator
-if django.VERSION < (1, 10):  # NOQA
-    from django.core.urlresolvers import reverse  # NOQA
-else:  # NOQA
-    from django.urls import reverse  # NOQA
-
-from django.http import Http404, HttpResponseRedirect, HttpResponse
-from django.shortcuts import render
-from django.utils.encoding import iri_to_uri
-from django.utils.translation import ugettext_lazy as _
-from django.views.decorators.cache import never_cache
-from django.utils.encoding import force_text
 from django.contrib import messages
-
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.core.paginator import Paginator
+from django.http import Http404, HttpResponseRedirect, HttpResponse
+from django.views.decorators.cache import never_cache
+from django.views.generic import TemplateView, View
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
+from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
+from django.utils.translation import ugettext_lazy as _
 from microsofttranslator import Translator, TranslateApiException
-
-from rosetta.conf import settings as rosetta_settings
 from polib import pofile
+import six
+import unicodedata
+
+from rosetta import get_version as get_rosetta_version
+from rosetta.access import can_translate, can_translate_language
+from rosetta.conf import settings as rosetta_settings
 from rosetta.poutil import find_pos, pagination_range, timestamp_with_timezone
 from rosetta.signals import entry_changed, post_save
 from rosetta.storage import get_storage
-from rosetta.access import can_translate, can_translate_language
-
-import json
-import re
-import rosetta
-import unicodedata
-import hashlib
-import os
-import six
 
 
-@never_cache
-@user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)
-def home(request):
-    """
-    Displays a list of messages to be translated
+def get_app_name(path):
+    return path.split('/locale')[0].split('/')[-1]
+
+
+class RosettaBaseMixin(object):
+    """A mixin class for Rosetta's class-based views. It provides:
+    * security (see decorated dispatch() method)
+    * a property for the 'po_filter' url argument
     """
 
-    def fix_nls(in_, out_):
+    # Handle security in our mixin
+    # NOTE: after we drop support for Django 1.8, we can employ these decorators
+    # more cleanly on the class itself, rather than the dispatch() method. (See
+    # the Django docs: https://docs.djangoproject.com/en/dev/topics/class-based-views/intro/#decorating-the-class)
+    @method_decorator(never_cache)
+    @method_decorator(login_required)
+    @method_decorator(user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL))
+    def dispatch(self, *args, **kwargs):
+        return super(RosettaBaseMixin, self).dispatch(*args, **kwargs)
+
+    @cached_property
+    def po_filter(self):
+        """Return the filter applied to all of the .po files under consideration
+        to determine which file is currently being translated. Options are:
+        'all', 'django', 'third-party', 'project'.
+
+        If the filter isn't in this list, throw a 404.
+        """
+        po_filter = self.kwargs['po_filter']
+        if po_filter not in {'all', 'django', 'third-party', 'project'}:
+            raise Http404
+        return po_filter
+
+
+class RosettaFileLevelMixin(RosettaBaseMixin):
+    """Mixin for dealing with views that work specifically with a single
+    .po file. In addition to what the super class brings, it adds the following
+    properties:
+    * language_id (e.g. 'fr'); derived from url, and validated
+    * po_file_path (filesystem path to catalog)
+    * po_file (pofile object)
+    * po_file_is_writable (bool: do we have filesystem write perms to file)
+    """
+    def _request_request(self, key, default=None):
+        if key in self.request.GET:
+            return self.request.GET.get(key)
+        elif key in self.request.POST:
+            return self.request.POST.get(key)
+        return default
+
+    @cached_property
+    def language_id(self):
+        """Determine/return the language id from the url kwargs, after
+        validating that:
+        1. the language is in settings.LANGUAGES, and
+        2. the current user is permitted to translate that language
+
+        (If either of the above fail, throw a 404.)
+        """
+        # (Formerly known as "rosetta_i18n_lang_code")
+        lang_id = self.kwargs['lang_id']
+        if lang_id not in {l[0] for l in settings.LANGUAGES}:
+            raise Http404
+        if not can_translate_language(self.request.user, lang_id):
+            raise Http404
+        return lang_id
+
+    @cached_property
+    def po_file_path(self):
+        """Based on the url kwargs, infer and return the path to the .po file to
+        be shown/updated.
+
+        Throw a 404 if a file isn't found.
+        """
+        # This was formerly referred to as 'rosetta_i18n_fn'
+        idx = self.kwargs['idx']
+        idx = int(idx)  # idx matched url re expression; calling int() is safe
+
+        third_party_apps = self.po_filter in ('all', 'third-party')
+        django_apps = self.po_filter in ('all', 'django')
+        project_apps = self.po_filter in ('all', 'project')
+
+        po_paths = find_pos(self.language_id,
+                            project_apps=project_apps,
+                            django_apps=django_apps,
+                            third_party_apps=third_party_apps,
+                            )
+        po_paths.sort(key=get_app_name)
+
+        try:
+            path = po_paths[idx]
+        except IndexError:
+            raise Http404
+        return path
+
+    @cached_property
+    def po_file(self):
+        """Return the parsed .po file that is currently being translated/viewed.
+
+        (Note that this parsing also involves marking up each entry with a hash
+        of its contents.)
+        """
+        if self.po_file_is_writable:
+            # If we can write changes to file, then we pull it up fresh with
+            # each request.
+            # XXX: brittle; what if this path doesn't exist? Isn't a .po file?
+            po_file = pofile(self.po_file_path,
+                             wrapwidth=rosetta_settings.POFILE_WRAP_WIDTH)
+            for entry in po_file:
+                # Entry is an object representing a single entry in the catalog.
+                # We interate through the *entire catalog*, pasting a hashed
+                # value of the meat of each entry on its side in an attribute
+                # called "md5hash".
+                str_to_hash = (
+                    six.text_type(entry.msgid) +
+                    six.text_type(entry.msgstr) +
+                    six.text_type(entry.msgctxt or '')
+                    ).encode('utf8')
+                entry.md5hash = hashlib.md5(str_to_hash).hexdigest()
+        else:
+            storage = get_storage(self.request)
+            po_file = storage.get(self.po_file_cache_key, None)
+            if not po_file:
+                po_file = pofile(self.po_file_path)
+                for entry in po_file:
+                    # Entry is an object representing a single entry in the
+                    # catalog. We interate through the entire catalog, pasting
+                    # a hashed value of the meat of each entry on its side in
+                    # an attribute called "md5hash".
+                    str_to_hash = (
+                        six.text_type(entry.msgid) +
+                        six.text_type(entry.msgstr) +
+                        six.text_type(entry.msgctxt or '')
+                        ).encode('utf8')
+                    entry.md5hash = hashlib.new('md5', str_to_hash).hexdigest()
+                storage.set(self.po_file_cache_key, po_file)
+        return po_file
+
+    @cached_property
+    def po_file_cache_key(self):
+        """Return the cache key used to save/access the .po file (when actually
+        persisted in cache).
+        """
+        return 'po-file-%s' % self.po_file_path
+
+    @cached_property
+    def po_file_is_writable(self):
+        """Return True if we're able (in terms of file system permissions) to
+        write out changes to the .po file we're translating.
+        """
+        # (This was formerly called 'rosetta_i18n_write'.)
+        return os.access(self.po_file_path, os.W_OK)
+
+
+class TranslationFileListView(RosettaBaseMixin, TemplateView):
+    """Lists the languages, the gettext catalog files that can be translated,
+    and their translation progress for a filtered list of apps/projects.
+    """
+    http_method_names = ['get']
+    template_name = 'rosetta/file-list.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(TranslationFileListView, self).get_context_data(**kwargs)
+
+        third_party_apps = self.po_filter in ('all', 'third-party')
+        django_apps = self.po_filter in ('all', 'django')
+        project_apps = self.po_filter in ('all', 'project')
+
+        languages = []
+        has_pos = False
+        for language in settings.LANGUAGES:
+            if not can_translate_language(self.request.user, language[0]):
+                continue
+
+            po_paths = find_pos(language[0],
+                                project_apps=project_apps,
+                                django_apps=django_apps,
+                                third_party_apps=third_party_apps,
+                                )
+            po_files = [(get_app_name(l), os.path.realpath(l), pofile(l)) for l in po_paths]
+            po_files.sort(key=lambda app: app[0])
+            languages.append((language[0], _(language[1]), po_files))
+            has_pos = has_pos or bool(po_paths)
+
+        try:
+            ADMIN_MEDIA_PREFIX = settings.ADMIN_MEDIA_PREFIX
+        except AttributeError:
+            ADMIN_MEDIA_PREFIX = settings.STATIC_URL + 'admin/'
+
+        context['version'] = get_rosetta_version(True)
+        context['ADMIN_MEDIA_PREFIX'] = ADMIN_MEDIA_PREFIX
+        context['languages'] = languages
+        context['has_pos'] = has_pos
+        context['po_filter'] = self.po_filter
+        return context
+
+
+class TranslationFormView(RosettaFileLevelMixin, TemplateView):
+    """Show a form with a page's worth of messages to be translated; handle its
+    submission by updating cached pofile and, if possible, writing out changes
+    to existing .po file.
+
+    Query strings that affect what's shown:
+    * msg_filter: filters which messages are displayed. One of 'all', 'fuzzy',
+      'translated', and 'untranslated'
+    * ref_lang: specifies which language should be shown as the source. Only
+      applicable when REF_LANG setting is set to True
+    * page: which page (number) should be shown of the paginated results (with
+      msg_filter or query applied)
+    * query: a search string, where only matches are shown. Fields that are
+      searched include: source, translated text, "occurence" file path, or
+      context hints.
+    """
+    # Note: due to the unorthodox nature of the form itself, we're not using
+    # Django's generic FormView as our base class.
+    http_method_names = ['get', 'post']
+    template_name = 'rosetta/form.html'
+
+    def fix_nls(self, in_, out_):
         """Fixes submitted translations by filtering carriage returns and pairing
         newlines at the begging and end of the translated string with the original
         """
@@ -62,420 +278,402 @@ def home(request):
             out_ = out_.rstrip()
         return out_
 
-    def _request_request(key, default=None):
-        if key in request.GET:
-            return request.GET.get(key)
-        elif key in request.POST:
-            return request.POST.get(key)
-        return default
+    def post(self, request, *args, **kwargs):
+        """The only circumstances when we POST is to submit the main form, both
+        updating translations (if any changed) and advancing to the next page of
+        messages.
 
-    storage = get_storage(request)
-    query = ''
-    if storage.has('rosetta_i18n_fn'):
-        rosetta_i18n_fn = storage.get('rosetta_i18n_fn')
+        There is no notion of validation of this content; as implemented, unknown
+        fields are ignored and a generic failure message is shown.
 
-        rosetta_i18n_app = get_app_name(rosetta_i18n_fn)
-        rosetta_i18n_lang_code = storage.get('rosetta_i18n_lang_code')
-        rosetta_i18n_lang_bidi = rosetta_i18n_lang_code.split('-')[0] in settings.LANGUAGES_BIDI
-        rosetta_i18n_write = storage.get('rosetta_i18n_write', True)
-        if rosetta_i18n_write:
-            rosetta_i18n_pofile = pofile(rosetta_i18n_fn, wrapwidth=rosetta_settings.POFILE_WRAP_WIDTH)
-            for entry in rosetta_i18n_pofile:
-                entry.md5hash = hashlib.md5(
-                    (six.text_type(entry.msgid) +
-                        six.text_type(entry.msgstr) +
-                        six.text_type(entry.msgctxt or "")).encode('utf8')
-                ).hexdigest()
+        Submitted changes are saved out to the specified .po file on the
+        filesystem if that file is writable, otherwise the cached version of the
+        file is updated (so it can be downloaded). Then the user is redirected
+        to the next page of messages (if there is one; otherwise they're
+        redirected back to the current page).
+        """
+        # The message text inputs are captured as hashes of their initial
+        # contents, preceded by "m_". Messages with plurals end with their
+        # variation number.
+        single_text_input_regex = re.compile(r'^m_([0-9a-f]+)$')
+        plural_text_input_regex = re.compile(r'^m_([0-9a-f]+)_([0-9]+)$')
+        file_change = False
+        for field_name, new_msgstr in request.POST.items():
+            md5hash = None
 
-        else:
-            rosetta_i18n_pofile = storage.get('rosetta_i18n_pofile')
+            if plural_text_input_regex.match(field_name):
+                md5hash, plural_id = plural_text_input_regex.match(field_name).groups()
+                md5hash = str(md5hash)
+                # polib parses .po files into unicode strings, but
+                # doesn't bother to convert plural indexes to int,
+                # so we need unicode here.
+                plural_id = six.text_type(plural_id)
 
-        if 'filter' in request.GET:
-            if request.GET.get('filter') in ('untranslated', 'translated', 'fuzzy', 'all'):
-                filter_ = request.GET.get('filter')
-                storage.set('rosetta_i18n_filter', filter_)
-                return HttpResponseRedirect(reverse('rosetta-home'))
+                # Above no longer true as of Polib 1.0.4
+                if plural_id and plural_id.isdigit():
+                    plural_id = int(plural_id)
 
-        rosetta_i18n_filter = storage.get('rosetta_i18n_filter', 'all')
-
-        if '_next' in request.POST:
-            rx = re.compile(r'^m_([0-9a-f]+)')
-            rx_plural = re.compile(r'^m_([0-9a-f]+)_([0-9]+)')
-            file_change = False
-            for key, value in request.POST.items():
-                md5hash = None
+            elif single_text_input_regex.match(field_name):
+                md5hash = str(single_text_input_regex.match(field_name).groups()[0])
                 plural_id = None
 
-                if rx_plural.match(key):
-                    md5hash = str(rx_plural.match(key).groups()[0])
-                    # polib parses .po files into unicode strings, but
-                    # doesn't bother to convert plural indexes to int,
-                    # so we need unicode here.
-                    plural_id = six.text_type(rx_plural.match(key).groups()[1])
-
-                    # Above no longer true as of Polib 1.0.4
-                    if plural_id and plural_id.isdigit():
-                        plural_id = int(plural_id)
-
-                elif rx.match(key):
-                    md5hash = str(rx.match(key).groups()[0])
-
-                if md5hash is not None:
-                    entry = rosetta_i18n_pofile.find(md5hash, 'md5hash')
-                    # If someone did a makemessage, some entries might
-                    # have been removed, so we need to check.
-                    if entry:
-                        old_msgstr = entry.msgstr
-                        if plural_id is not None:
-                            plural_string = fix_nls(entry.msgid_plural, value)
-                            entry.msgstr_plural[plural_id] = plural_string
-                        else:
-                            entry.msgstr = fix_nls(entry.msgid, value)
-
-                        is_fuzzy = bool(request.POST.get('f_%s' % md5hash, False))
-                        old_fuzzy = 'fuzzy' in entry.flags
-
-                        if old_fuzzy and not is_fuzzy:
-                            entry.flags.remove('fuzzy')
-                        elif not old_fuzzy and is_fuzzy:
-                            entry.flags.append('fuzzy')
-
-                        file_change = True
-
-                        if old_msgstr != value or old_fuzzy != is_fuzzy:
-                            entry_changed.send(sender=entry,
-                                               user=request.user,
-                                               old_msgstr=old_msgstr,
-                                               old_fuzzy=old_fuzzy,
-                                               pofile=rosetta_i18n_fn,
-                                               language_code=rosetta_i18n_lang_code,
-                                               )
-
+            if md5hash is not None:  # Empty string should be processed!
+                entry = self.po_file.find(md5hash, 'md5hash')
+                # If someone did a makemessage, some entries might
+                # have been removed, so we need to check.
+                if entry:
+                    old_msgstr = entry.msgstr
+                    if plural_id is not None:  # 0 is ok!
+                        entry.msgstr_plural[plural_id] = self.fix_nls(
+                            entry.msgid_plural, new_msgstr
+                            )
                     else:
-                        storage.set('rosetta_last_save_error', True)
+                        entry.msgstr = self.fix_nls(entry.msgid, new_msgstr)
 
-            if file_change and rosetta_i18n_write:
-                try:
-                    rosetta_i18n_pofile.metadata['Last-Translator'] = unicodedata.normalize('NFKD', u"%s %s <%s>" % (
-                        getattr(request.user, 'first_name', 'Anonymous'),
-                        getattr(request.user, 'last_name', 'User'),
-                        getattr(request.user, 'email', 'anonymous@user.tld')
-                    )).encode('ascii', 'ignore')
-                    rosetta_i18n_pofile.metadata['X-Translated-Using'] = u"django-rosetta %s" % rosetta.get_version(False)
-                    rosetta_i18n_pofile.metadata['PO-Revision-Date'] = timestamp_with_timezone()
-                except UnicodeDecodeError:
-                    pass
+                    is_fuzzy = bool(
+                        self.request.POST.get('f_%s' % md5hash, False)
+                        )
+                    old_fuzzy = 'fuzzy' in entry.flags
 
-                try:
-                    rosetta_i18n_pofile.save()
-                    po_filepath, ext = os.path.splitext(rosetta_i18n_fn)
+                    if old_fuzzy and not is_fuzzy:
+                        entry.flags.remove('fuzzy')
+                    elif not old_fuzzy and is_fuzzy:
+                        entry.flags.append('fuzzy')
 
-                    if rosetta_settings.AUTO_COMPILE:
-                        save_as_mo_filepath = po_filepath + '.mo'
-                        rosetta_i18n_pofile.save_as_mofile(save_as_mo_filepath)
+                    file_change = True
 
-                    post_save.send(sender=None, language_code=rosetta_i18n_lang_code, request=request)
-                    # Try auto-reloading via the WSGI daemon mode reload mechanism
-                    if rosetta_settings.WSGI_AUTO_RELOAD and \
-                        'mod_wsgi.process_group' in request.environ and \
-                        request.environ.get('mod_wsgi.process_group', None) and \
-                        'SCRIPT_FILENAME' in request.environ and \
-                            int(request.environ.get('mod_wsgi.script_reloading', '0')):
-                            try:
-                                os.utime(request.environ.get('SCRIPT_FILENAME'), None)
-                            except OSError:
-                                pass
-                    # Try auto-reloading via uwsgi daemon reload mechanism
-                    if rosetta_settings.UWSGI_AUTO_RELOAD:
-                        try:
-                            import uwsgi
-                            # pretty easy right?
-                            uwsgi.reload()
-                        except:
-                            # we may not be running under uwsgi :P
-                            pass
+                    if old_msgstr != new_msgstr or old_fuzzy != is_fuzzy:
+                        entry_changed.send(sender=entry,
+                                           user=request.user,
+                                           old_msgstr=old_msgstr,
+                                           old_fuzzy=old_fuzzy,
+                                           pofile=self.po_file_path,
+                                           language_code=self.language_id,
+                                           )
+                else:
+                    messages.error(
+                        self.request,
+                        _("Some items in your last translation block couldn't "
+                          "be saved: this usually happens when the catalog file "
+                          "changes on disk after you last loaded it."),
+                        )
 
-                except Exception as e:
-                    messages.error(request, e)
-                    storage.set('rosetta_i18n_write', False)
-                storage.set('rosetta_i18n_pofile', rosetta_i18n_pofile)
-
-                # Retain query arguments
-                query_arg = '?_next=1'
-                if _request_request('query', False):
-                    query_arg += '&query=%s' % _request_request('query')
-                if 'page' in request.GET:
-                    query_arg += '&page=%d&_next=1' % int(request.GET.get('page'))
-                return HttpResponseRedirect(reverse('rosetta-home') + iri_to_uri(query_arg))
-        rosetta_i18n_lang_code = storage.get('rosetta_i18n_lang_code')
-
-        if _request_request('query', False) and _request_request('query', '').strip():
-            query = _request_request('query', '').strip()
-            rx = re.compile(re.escape(query), re.IGNORECASE)
-            paginator = Paginator([e_ for e_ in rosetta_i18n_pofile if not e_.obsolete and rx.search(six.text_type(e_.msgstr) + six.text_type(e_.msgid) + six.text_type(e_.comment) + u''.join([o[0] for o in e_.occurrences]))], rosetta_settings.MESSAGES_PER_PAGE)
-        else:
-            if rosetta_i18n_filter == 'untranslated':
-                paginator = Paginator(rosetta_i18n_pofile.untranslated_entries(), rosetta_settings.MESSAGES_PER_PAGE)
-            elif rosetta_i18n_filter == 'translated':
-                paginator = Paginator(rosetta_i18n_pofile.translated_entries(), rosetta_settings.MESSAGES_PER_PAGE)
-            elif rosetta_i18n_filter == 'fuzzy':
-                paginator = Paginator([e_ for e_ in rosetta_i18n_pofile.fuzzy_entries() if not e_.obsolete], rosetta_settings.MESSAGES_PER_PAGE)
-            else:
-                paginator = Paginator([e_ for e_ in rosetta_i18n_pofile if not e_.obsolete], rosetta_settings.MESSAGES_PER_PAGE)
-
-        if rosetta_settings.ENABLE_REFLANG:
-            ref_lang = storage.get('rosetta_i18n_ref_lang_code', 'msgid')
-            ref_pofile = None
-            if ref_lang != 'msgid':
-                ref_fn = re.sub('/locale/[a-z]{2}/', '/locale/%s/' % ref_lang, rosetta_i18n_fn)
-                try:
-                    ref_pofile = pofile(ref_fn)
-                except IOError:
-                    # there's a syntax error in the PO file and polib can't open it. Let's just
-                    # do nothing and thus display msgids.
-                    pass
-
-            for o in paginator.object_list:
-                # default
-                o.ref_txt = o.msgid
-                if ref_pofile is not None:
-                    ref_entry = ref_pofile.find(o.msgid)
-                    if ref_entry is not None and ref_entry.msgstr:
-                        o.ref_txt = ref_entry.msgstr
-            LANGUAGES = list(settings.LANGUAGES) + [('msgid', 'MSGID')]
-        else:
-            ref_lang = None
-            LANGUAGES = settings.LANGUAGES
-
-        page = 1
-        if 'page' in request.GET:
+        if file_change and self.po_file_is_writable:
             try:
-                get_page = int(request.GET.get('page'))
-            except ValueError:
-                page = 1  # fall back to page 1
-            else:
-                if 0 < get_page <= paginator.num_pages:
-                    page = get_page
+                self.po_file.metadata['Last-Translator'] = unicodedata.normalize(
+                    'NFKD', u"%s %s <%s>" % (
+                        getattr(self.request.user, 'first_name', 'Anonymous'),
+                        getattr(self.request.user, 'last_name', 'User'),
+                        getattr(self.request.user, 'email', 'anonymous@user.tld')
+                        )
+                    ).encode('ascii', 'ignore')
+                self.po_file.metadata['X-Translated-Using'] = u"django-rosetta %s" % (
+                    get_rosetta_version(False)
+                    )
+                self.po_file.metadata['PO-Revision-Date'] = timestamp_with_timezone()
+            except UnicodeDecodeError:
+                pass
+            try:
+                self.po_file.save()
+                po_filepath, ext = os.path.splitext(self.po_file_path)
 
-        if '_next' in request.GET or '_next' in request.POST:
-            page += 1
-            if page > paginator.num_pages:
+                if rosetta_settings.AUTO_COMPILE:
+                    self.po_file.save_as_mofile(po_filepath + '.mo')
+
+                post_save.send(sender=None, language_code=self.language_id,
+                               request=self.request
+                               )
+                # Try auto-reloading via the WSGI daemon mode reload mechanism
+                should_try_wsgi_reload = (
+                    rosetta_settings.WSGI_AUTO_RELOAD and
+                    'mod_wsgi.process_group' in self.request.environ and
+                    self.request.environ.get('mod_wsgi.process_group', None) and
+                    'SCRIPT_FILENAME' in self.request.environ and
+                    int(self.request.environ.get('mod_wsgi.script_reloading', 0))
+                    )
+                if should_try_wsgi_reload:
+                    try:
+                        os.utime(self.request.environ.get('SCRIPT_FILENAME'), None)
+                    except OSError:
+                        pass
+                # Try auto-reloading via uwsgi daemon reload mechanism
+                if rosetta_settings.UWSGI_AUTO_RELOAD:
+                    try:
+                        import uwsgi
+                        uwsgi.reload()  # pretty easy right?
+                    except:
+                        pass  # we may not be running under uwsgi :P
+                # XXX: It would be nice to add a success message here!
+            except Exception as e:
+                messages.error(self.request, e)
+
+        if file_change and not self.po_file_is_writable:
+            storage = get_storage(self.request)
+            storage.set(self.po_file_cache_key, self.po_file)
+
+        # Reconstitute url to redirect to. Start with determining whether the
+        # page number can be incremented.
+        paginator = Paginator(self.get_entries(), rosetta_settings.MESSAGES_PER_PAGE)
+        try:
+            page = int(self._request_request('page', 1))
+        except ValueError:
+            page = 1  # fall back to page 1
+        else:
+            if not (0 < page <= paginator.num_pages):
                 page = 1
-            query_arg = '?page=%d' % page
-            return HttpResponseRedirect(reverse('rosetta-home') + iri_to_uri(query_arg))
+        if page < paginator.num_pages:
+            page += 1
+        query_string_args = {
+            'msg_filter': self.msg_filter,
+            'query': self.query,
+            'ref_lang': self.ref_lang,
+            'page': page,
+            }
+        # Winnow down the query string args to non-blank ones
+        query_string_args = {k: v for k, v in query_string_args.items() if v}
+        return HttpResponseRedirect("{url}?{qs}".format(
+            url=reverse('rosetta-form', kwargs=self.kwargs),
+            qs=urlencode(query_string_args),
+            ))
 
-        rosetta_messages = paginator.page(page).object_list
-        main_language = None
-        if rosetta_settings.MAIN_LANGUAGE and rosetta_settings.MAIN_LANGUAGE != rosetta_i18n_lang_code:
-            for language in settings.LANGUAGES:
-                if language[0] == rosetta_settings.MAIN_LANGUAGE:
-                    main_language = _(language[1])
-                    break
+    def get_context_data(self, **kwargs):
+        context = super(TranslationFormView, self).get_context_data(**kwargs)
+        entries = self.get_entries()
+        paginator = Paginator(entries, rosetta_settings.MESSAGES_PER_PAGE)
 
-            fl = ("/%s/" % rosetta_settings.MAIN_LANGUAGE).join(rosetta_i18n_fn.split("/%s/" % rosetta_i18n_lang_code))
-            po = pofile(fl)
+        # Handle REF_LANG setting; mark up our entries with the reg lang's
+        # corresponding translations
+        LANGUAGES = list(settings.LANGUAGES)
+        if rosetta_settings.ENABLE_REFLANG:
+            if self.ref_lang_po_file:
+                for o in paginator.object_list:
+                    ref_entry = self.ref_lang_po_file.find(o.msgid)
+                    if ref_entry and ref_entry.msgstr:
+                        o.ref_txt = ref_entry.msgstr
+                    else:
+                        o.ref_txt = o.msgid
+            else:
+                for o in paginator.object_list:
+                    o.ref_txt = o.msgid
+            # XXX: having "MSGID" at the end of the dropdown is really odd, no?
+            # Why not instead do this?
+            # LANGUAGES = [('', '----')] + list(settings.LANGUAGES)
+            LANGUAGES.append(('msgid', 'MSGID'))
 
-            for message in rosetta_messages:
-                message.main_lang = po.find(message.msgid).msgstr
-
+        # Determine page number & how pagination links should be displayed
+        try:
+            page = int(self._request_request('page', 1))
+        except ValueError:
+            page = 1  # fall back to page 1
+        else:
+            if not (0 < page <= paginator.num_pages):
+                page = 1
         needs_pagination = paginator.num_pages > 1
         if needs_pagination:
             if paginator.num_pages >= 10:
                 page_range = pagination_range(1, paginator.num_pages, page)
             else:
                 page_range = range(1, 1 + paginator.num_pages)
+
+        rosetta_messages = paginator.page(page).object_list
+
+        # Handle MAIN_LANGUAGE setting, if applicable; mark up each entry
+        # in the pagination window with the "main language"'s string.
+        main_language_id = rosetta_settings.MAIN_LANGUAGE
+        main_language = None
+        if main_language_id and main_language_id != self.language_id:
+            # Translate from id to language name
+            for language in settings.LANGUAGES:
+                if language[0] == main_language_id:
+                    main_language = _(language[1])
+                    break
+        if main_language:
+            main_lang_po_path = self.po_file_path.replace(
+                '/%s/' % self.language_id,
+                '/%s/' % main_language_id,
+                )
+            # XXX: brittle; what if this path doesn't exist? Isn't a .po file?
+            main_lang_po = pofile(main_lang_po_path)
+
+            for message in rosetta_messages:
+                message.main_lang = main_lang_po.find(message.msgid).msgstr
+
+        # Collect some constants for the template
         try:
             ADMIN_MEDIA_PREFIX = settings.ADMIN_MEDIA_PREFIX
             ADMIN_IMAGE_DIR = ADMIN_MEDIA_PREFIX + 'img/admin/'
         except AttributeError:
             ADMIN_MEDIA_PREFIX = settings.STATIC_URL + 'admin/'
             ADMIN_IMAGE_DIR = ADMIN_MEDIA_PREFIX + 'img/'
-
-        if storage.has('rosetta_last_save_error'):
-            storage.delete('rosetta_last_save_error')
-            rosetta_last_save_error = True
-        else:
-            rosetta_last_save_error = False
-
-        try:
-            rosetta_i18n_lang_name = force_text(_(storage.get('rosetta_i18n_lang_name')))
-        except:
-            rosetta_i18n_lang_name = force_text(storage.get('rosetta_i18n_lang_name'))
-
-        return render(request, 'rosetta/pofile.html', dict(
-            version=rosetta.get_version(True),
-            ADMIN_MEDIA_PREFIX=ADMIN_MEDIA_PREFIX,
-            ADMIN_IMAGE_DIR=ADMIN_IMAGE_DIR,
-            ENABLE_REFLANG=rosetta_settings.ENABLE_REFLANG,
-            LANGUAGES=LANGUAGES,
-            rosetta_settings=rosetta_settings,
-            rosetta_i18n_lang_name=rosetta_i18n_lang_name,
-            rosetta_i18n_lang_code=rosetta_i18n_lang_code,
-            rosetta_i18n_lang_bidi=rosetta_i18n_lang_bidi,
-            rosetta_last_save_error=rosetta_last_save_error,
-            rosetta_i18n_filter=rosetta_i18n_filter,
-            rosetta_i18n_write=rosetta_i18n_write,
-            rosetta_messages=rosetta_messages,
-            page_range=needs_pagination and page_range,
-            needs_pagination=needs_pagination,
-            main_language=main_language,
-            rosetta_i18n_app=rosetta_i18n_app,
-            page=page,
-            query=query,
-            paginator=paginator,
-            rosetta_i18n_pofile=rosetta_i18n_pofile,
-            ref_lang=ref_lang,
-        ))
-    else:
-        return list_languages(request, do_session_warn=True)
-
-
-@never_cache
-@user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)
-def download_file(request):
-    import zipfile
-    storage = get_storage(request)
-    # original filename
-    rosetta_i18n_fn = storage.get('rosetta_i18n_fn', None)
-    # in-session modified catalog
-    rosetta_i18n_pofile = storage.get('rosetta_i18n_pofile', None)
-    # language code
-    rosetta_i18n_lang_code = storage.get('rosetta_i18n_lang_code', None)
-
-    if not rosetta_i18n_lang_code or not rosetta_i18n_pofile or not rosetta_i18n_fn:
-        return HttpResponseRedirect(reverse('rosetta-home'))
-    try:
-        if len(rosetta_i18n_fn.split('/')) >= 5:
-            offered_fn = '_'.join(rosetta_i18n_fn.split('/')[-5:])
-        else:
-            offered_fn = rosetta_i18n_fn.split('/')[-1]
-        po_fn = str(rosetta_i18n_fn.split('/')[-1])
-        mo_fn = str(po_fn.replace('.po', '.mo'))  # not so smart, huh
-        zipdata = six.BytesIO()
-        zipf = zipfile.ZipFile(zipdata, mode="w")
-        zipf.writestr(po_fn, six.text_type(rosetta_i18n_pofile).encode("utf8"))
-        zipf.writestr(mo_fn, rosetta_i18n_pofile.to_binary())
-        zipf.close()
-        zipdata.seek(0)
-
-        response = HttpResponse(zipdata.read())
-        response['Content-Disposition'] = 'attachment; filename=%s.%s.zip' % (offered_fn, rosetta_i18n_lang_code)
-        response['Content-Type'] = 'application/x-zip'
-        return response
-
-    except Exception:
-        return HttpResponseRedirect(reverse('rosetta-home'))
-
-
-@never_cache
-@user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)
-def list_languages(request, do_session_warn=False):
-    """
-    Lists the languages for the current project, the gettext catalog files
-    that can be translated and their translation progress
-    """
-    storage = get_storage(request)
-    languages = []
-
-    if 'filter' in request.GET:
-        if request.GET.get('filter') in ('project', 'third-party', 'django', 'all'):
-            filter_ = request.GET.get('filter')
-            storage.set('rosetta_i18n_catalog_filter', filter_)
-            return HttpResponseRedirect(reverse('rosetta-pick-file'))
-
-    rosetta_i18n_catalog_filter = storage.get('rosetta_i18n_catalog_filter', 'project')
-
-    third_party_apps = rosetta_i18n_catalog_filter in ('all', 'third-party')
-    django_apps = rosetta_i18n_catalog_filter in ('all', 'django')
-    project_apps = rosetta_i18n_catalog_filter in ('all', 'project')
-
-    has_pos = False
-    for language in settings.LANGUAGES:
-        if not can_translate_language(request.user, language[0]):
-            continue
-
-        pos = find_pos(language[0], project_apps=project_apps, django_apps=django_apps, third_party_apps=third_party_apps)
-        has_pos = has_pos or len(pos)
-        languages.append(
-            (
-                language[0],
-                _(language[1]),
-                sorted([(get_app_name(l), os.path.realpath(l), pofile(l)) for l in pos], key=lambda app: app[0]),
+        rosetta_i18n_lang_name = six.text_type(
+            dict(settings.LANGUAGES).get(self.language_id)
             )
-        )
-    try:
-        ADMIN_MEDIA_PREFIX = settings.ADMIN_MEDIA_PREFIX
-    except AttributeError:
-        ADMIN_MEDIA_PREFIX = settings.STATIC_URL + 'admin/'
-    do_session_warn = do_session_warn and 'SessionRosettaStorage' in rosetta_settings.STORAGE_CLASS and 'signed_cookies' in settings.SESSION_ENGINE
+        # "bidi" as in "bi-directional"
+        rosetta_i18n_lang_bidi = self.language_id.split('-')[0] in settings.LANGUAGES_BIDI
+        query_string_args = {}
+        if self.msg_filter:
+            query_string_args['msg_filter'] = self.msg_filter
+        if self.query:
+            query_string_args['query'] = self.query
+        if self.ref_lang:
+            query_string_args['ref_lang'] = self.ref_lang
+        # Base for pagination links; the page num itself is added in template
+        pagination_query_string_base = urlencode(query_string_args)
+        # Base for msg filter links; it doesn't make sense to persist page
+        # numbers in these links. We just pass in ref_lang, if it's set.
+        filter_query_string_base = urlencode(
+            {k: v for k, v in query_string_args.items() if k == 'ref_lang'}
+            )
 
-    return render(request, 'rosetta/languages.html', dict(
-        version=rosetta.get_version(True),
-        ADMIN_MEDIA_PREFIX=ADMIN_MEDIA_PREFIX,
-        do_session_warn=do_session_warn,
-        languages=languages,
-        has_pos=has_pos,
-        rosetta_i18n_catalog_filter=rosetta_i18n_catalog_filter
-    ))
+        context.update({
+            'version': get_rosetta_version(True),
+            'ADMIN_MEDIA_PREFIX': ADMIN_MEDIA_PREFIX,
+            'ADMIN_IMAGE_DIR': ADMIN_IMAGE_DIR,
+            'LANGUAGES': LANGUAGES,
+            'rosetta_settings': rosetta_settings,
+            'rosetta_i18n_lang_name': rosetta_i18n_lang_name,
+            'rosetta_i18n_lang_code': self.language_id,
+            'rosetta_i18n_lang_bidi': rosetta_i18n_lang_bidi,
+            'rosetta_i18n_filter': self.msg_filter,
+            'rosetta_i18n_write': self.po_file_is_writable,
+            'rosetta_messages': rosetta_messages,
+            'page_range': needs_pagination and page_range,
+            'needs_pagination': needs_pagination,
+            'main_language': main_language,
+            'rosetta_i18n_app': get_app_name(self.po_file_path),
+            'page': page,
+            'query': self.query,
+            'pagination_query_string_base': pagination_query_string_base,
+            'filter_query_string_base': filter_query_string_base,
+            'paginator': paginator,
+            'rosetta_i18n_pofile': self.po_file,
+            'ref_lang': self.ref_lang,
+            })
+
+        return context
+
+    @cached_property
+    def ref_lang(self):
+        """Return the language id for the "reference language" (the language to
+        be translated *from*, if not English).
+
+        Throw a 404 if it's not in settings.LANGUAGES.
+        """
+        ref_lang = self._request_request('ref_lang', 'msgid')
+        if ref_lang != 'msgid':
+            allowed_languages = {l[0] for l in settings.LANGUAGES}
+            if ref_lang not in allowed_languages:
+                raise Http404
+        return ref_lang
+
+    @cached_property
+    def ref_lang_po_file(self):
+        """Return a parsed .po file object for the "reference language", if one
+        exists, otherwise None.
+        """
+        ref_pofile = None
+        if rosetta_settings.ENABLE_REFLANG and self.ref_lang != 'msgid':
+            ref_fn = re.sub(
+                '/locale/[a-z]{2}/',
+                '/locale/%s/' % (self.ref_lang),
+                self.po_file_path,
+                )
+            try:
+                ref_pofile = pofile(ref_fn)
+            except IOError:
+                # there's a syntax error in the PO file and polib can't
+                # open it. Let's just do nothing and thus display msgids.
+                # XXX: :-/
+                pass
+        return ref_pofile
+
+    @cached_property
+    def msg_filter(self):
+        """Validate/return msg_filter from request (e.g. 'fuzzy', 'untranslated'),
+        or a default.
+
+        If a query is also specified in the request, then return None.
+        """
+        if self.query:
+            msg_filter = None
+        else:
+            msg_filter = self._request_request('msg_filter', 'all')
+            available_msg_filters = {'untranslated', 'translated', 'fuzzy', 'all'}
+            if msg_filter not in available_msg_filters:
+                msg_filter = 'all'
+        return msg_filter
+
+    @cached_property
+    def query(self):
+        """Strip and return the query (for searching the catalog) from the
+        request, or None.
+        """
+        return self._request_request('query', '').strip() or None
+
+    def get_entries(self):
+        """Return a list of the entries (messages) that would be part of the
+        current "view"; that is, all of the ones from this .po file matching the
+        current query or msg_filter.
+        """
+        if self.query:
+            # Scenario #1: terms matching a search query
+            rx = re.compile(re.escape(self.query), re.IGNORECASE)
+
+            def concat_entry(e):
+                return (six.text_type(e.msgstr) +
+                        six.text_type(e.msgid) +
+                        six.text_type(e.comment) +
+                        u''.join([o[0] for o in e.occurrences])
+                        )
+
+            entries = [e_ for e_ in self.po_file
+                       if not e_.obsolete and rx.search(concat_entry(e_))]
+        else:
+            # Scenario #2: filtered list of messages
+            if self.msg_filter == 'untranslated':
+                entries = self.po_file.untranslated_entries()
+            elif self.msg_filter == 'translated':
+                entries = self.po_file.translated_entries()
+            elif self.msg_filter == 'fuzzy':
+                entries = [e_ for e_ in self.po_file.fuzzy_entries()
+                           if not e_.obsolete]
+            else:
+                # ("all")
+                entries = [e_ for e_ in self.po_file if not e_.obsolete]
+        return entries
 
 
-def get_app_name(path):
-    app = path.split("/locale")[0].split("/")[-1]
-    return app
-
-
-@never_cache
-@user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)
-def lang_sel(request, langid, idx):
+class TranslationFileDownload(RosettaFileLevelMixin, View):
+    """Download a zip file for a specific catalog including both the raw (.po)
+    and compiled (.mo) files, either as they exist on disk, or, if what's on
+    disk is unwritable (permissions-wise), return what's in the cache.
     """
-    Selects a file to be translated
-    """
-    storage = get_storage(request)
-    if langid not in [l[0] for l in settings.LANGUAGES] or not can_translate_language(request.user, langid):
-        raise Http404
-    else:
+    http_method_names = [u'get']
 
-        rosetta_i18n_catalog_filter = storage.get('rosetta_i18n_catalog_filter', 'project')
-
-        third_party_apps = rosetta_i18n_catalog_filter in ('all', 'third-party')
-        django_apps = rosetta_i18n_catalog_filter in ('all', 'django')
-        project_apps = rosetta_i18n_catalog_filter in ('all', 'project')
-        file_ = sorted(find_pos(langid, project_apps=project_apps, django_apps=django_apps, third_party_apps=third_party_apps), key=get_app_name)[int(idx)]
-
-        storage.set('rosetta_i18n_lang_code', langid)
-        storage.set('rosetta_i18n_lang_name', six.text_type([l[1] for l in settings.LANGUAGES if l[0] == langid][0]))
-        storage.set('rosetta_i18n_fn', file_)
-        po = pofile(file_)
-        for entry in po:
-            entry.md5hash = hashlib.new(
-                'md5',
-                (six.text_type(entry.msgid) +
-                    six.text_type(entry.msgstr) +
-                    six.text_type(entry.msgctxt or "")).encode('utf8')
-            ).hexdigest()
-
-        storage.set('rosetta_i18n_pofile', po)
+    def get(self, request, *args, **kwargs):
         try:
-            os.utime(file_, None)
-            storage.set('rosetta_i18n_write', True)
-        except OSError:
-            storage.set('rosetta_i18n_write', False)
+            if len(self.po_file_path.split('/')) >= 5:
+                offered_fn = '_'.join(self.po_file_path.split('/')[-5:])
+            else:
+                offered_fn = self.po_file_path.split('/')[-1]
+            po_fn = str(self.po_file_path.split('/')[-1])
+            mo_fn = str(po_fn.replace('.po', '.mo'))  # not so smart, huh
+            zipdata = six.BytesIO()
+            with zipfile.ZipFile(zipdata, mode="w") as zipf:
+                zipf.writestr(po_fn, six.text_type(self.po_file).encode("utf8"))
+                zipf.writestr(mo_fn, self.po_file.to_binary())
+            zipdata.seek(0)
 
-        return HttpResponseRedirect(reverse('rosetta-home'))
-
-
-def ref_sel(request, langid):
-    storage = get_storage(request)
-    ALLOWED_LANGUAGES = [l[0] for l in settings.LANGUAGES] + ['msgid']
-
-    if langid not in ALLOWED_LANGUAGES:
-        raise Http404
-
-    storage.set('rosetta_i18n_ref_lang_code', langid)
-
-    return HttpResponseRedirect(reverse('rosetta-home'))
-ref_sel = never_cache(ref_sel)
-ref_sel = user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)(ref_sel)
+            response = HttpResponse(zipdata.read())
+            filename = 'filename=%s.%s.zip' % (offered_fn, self.language_id)
+            response['Content-Disposition'] = 'attachment; %s' % filename
+            response['Content-Type'] = 'application/x-zip'
+            return response
+        except Exception:
+            # XXX: should add a message!
+            return HttpResponseRedirect(
+                reverse('rosetta-file-list', kwargs={'po_filter': 'project'})
+                )
 
 
 @user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)
@@ -498,6 +696,9 @@ def translate_text(request):
             translated_text = translator.translate(text, language_to, language_from)
             data = {'success': True, 'translation': translated_text}
         except TranslateApiException as e:
-            data = {'success': False, 'error': "Translation API Exception: {0}".format(e.message)}
+            data = {
+                'success': False,
+                'error': "Translation API Exception: {0}".format(e.message),
+                }
 
     return HttpResponse(json.dumps(data), content_type='application/json')


### PR DESCRIPTION
Previously, state was extensively persisted in the cache. This
large-scale rewrite uses the cache only to persist changes to the
catalog file when it is read-only. State is now conveyed through the url
structure and through query string arguments.

I have rewritten all of the views but one, as well as the meat of each of the tests (as well as adding a few new tests). Reading this pull request as a diff would be crazy-making; unfortunately, you probably
will need to read the new code line by line. I have attempted to be verbose in my documentation and variable names, but please let me know if any of the changes are confusing. Particularly note the implications on how/when the cache is used now.

The primary downside to this new approach is that there's no explicit
way of purging a cached catalog from memory, or refreshing it from
what's on disk. The user is forced (untransparently!) to wait until
the cached file falls out of the cache (untransparently!), which
is currently 24 hours after the last save (or after if the session
ends). Addressing this would require some design considerations,
and probably some new text that would require its own translation.

I am open to any and all changes, especially regarding the new URL structure. I am also willing to continue an active role as a contributor to this project as needed.

### All Submissions:

- [X] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [X] I have added or updated a test to cover the changes proposed in this Pull Request
- [N/A] I have updated the documentation to cover the changes proposed in this Pull Request