### PR TITLE
Search plurals (issue 186)

### DIFF
--- a/rosetta/templates/rosetta/form.html
+++ b/rosetta/templates/rosetta/form.html
@@ -50,7 +50,7 @@
             <form id="changelist-search" action="" method="get">
                 <div>
                     <label for="searchbar"><img src="{% static "admin/img/icon_searchbox_rosetta.png" %}" alt="{% trans "Search" %}" /></label>
-                    <input type="text" size="40" name="query" value="{{query}}" id="searchbar" tabindex="0" />
+                    <input type="text" size="40" name="query" value="{% if query %}{{query}}{% endif %}" id="searchbar" tabindex="0" />
                     <input type="submit" name="s" value="{% trans "Go" %}" />
                 </div>
             </form>

--- a/rosetta/templates/rosetta/form.html
+++ b/rosetta/templates/rosetta/form.html
@@ -38,10 +38,10 @@
 
     <ul class="object-tools">
         <li class="nobubble">{% trans "Display:" %}</li>
-        <li {% if rosetta_i18n_filter == 'untranslated' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=untranslated">{% trans "Untranslated only" %}</a></li>
-        <li {% if rosetta_i18n_filter == 'translated' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=translated">{% trans "Translated only" %}</a></li>
-        <li {% if rosetta_i18n_filter == 'fuzzy' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=fuzzy">{% trans "Fuzzy only" %}</a></li>
-        <li {% if rosetta_i18n_filter == 'all' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&msg_filter=all">{% trans "All" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'untranslated' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&amp;msg_filter=untranslated">{% trans "Untranslated only" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'translated' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&amp;msg_filter=translated">{% trans "Translated only" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'fuzzy' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&amp;msg_filter=fuzzy">{% trans "Fuzzy only" %}</a></li>
+        <li {% if rosetta_i18n_filter == 'all' %}class="active"{% endif %}><a href="?{{ filter_query_string_base }}&amp;msg_filter=all">{% trans "All" %}</a></li>
     </ul>
     <div id="changelist" class="module{% if rosetta_i18n_lang_bidi %} rtl{% endif %}">
 
@@ -157,7 +157,7 @@
                         {% if i == page %}
                             <span class="this-page">{{i}}</span>
                         {% else %}
-                            <a href="?{{ pagination_query_string_base }}&page={{i}}">{{i}}</a>
+                            <a href="?{{ pagination_query_string_base }}&amp;page={{i}}">{{i}}</a>
                         {% endif %}
                         {% endif %}
                     {% endfor %}

--- a/rosetta/tests/django.po.issue186.template
+++ b/rosetta/tests/django.po.issue186.template
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+msgid ""
+msgstr ""
+"Project-Id-Version: Rosetta\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-10-21 12:21+0200\n"
+"PO-Revision-Date: 2008-09-22 11:02\n"
+"Last-Translator: Admin Admin <admin@admin.com>\n"
+"Language-Team: French <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Translated-Using: django-rosetta 0.4.RC2\n"
+
+
+msgid "String 1"
+msgstr ""
+
+msgid "String 2"
+msgstr ""
+
+#. Translators: This is a text of the base template
+#: templates/base.html:43
+msgid "String 3 with comment"
+msgstr ""
+
+msgctxt "Context hint"
+msgid "String 4"
+msgstr ""
+
+msgid "%d Child"
+msgid_plural "%d Childrenen"
+msgstr[0] "%d Tchilt"
+msgstr[1] "%d Tchildren"

--- a/rosetta/tests/tests.py
+++ b/rosetta/tests/tests.py
@@ -938,6 +938,35 @@ class RosettaTestCase(TestCase):
         r = self.client.get(url % 'adipisicing')
         self.assertContains(r, 'Lorem')
 
+    def test_45_issue186_plural_msg_search(self):
+        """Confirm that search of the .po file works for plurals.
+        """
+        self.copy_po_file_from_template('./django.po.issue186.template')
+        url = self.xx_form_url + '?query=%s'
+
+        # Here's the message entry we're considering:
+        # msgstr "%d Child"
+        # msgid_plural "%d Childrenen"
+        # msgstr[0] "%d Tchilt"
+        # msgstr[1] "%d Tchildren"
+
+        # First, confirm that we don't ALWAYS see this particular message on the
+        # page.
+        r = self.client.get(url % 'kids')
+        self.assertNotContains(r, 'Child')
+
+        # Search msgid_plural
+        r = self.client.get(url % 'childrenen')
+        self.assertContains(r, 'Child')
+
+        # Search msgstr[0]
+        r = self.client.get(url % 'tchilt')
+        self.assertContains(r, 'Child')
+
+        # Search msgstr[1]
+        r = self.client.get(url % 'tchildren')
+        self.assertContains(r, 'Child')
+
 
 # Stubbed access control function
 def no_access(user):

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -620,7 +620,9 @@ class TranslationFormView(RosettaFileLevelMixin, TemplateView):
                 return (six.text_type(e.msgstr) +
                         six.text_type(e.msgid) +
                         six.text_type(e.comment) +
-                        u''.join([o[0] for o in e.occurrences])
+                        u''.join([o[0] for o in e.occurrences]) +
+                        six.text_type(e.msgid_plural) +
+                        u''.join(e.msgstr_plural.values())
                         )
 
             entries = [e_ for e_ in self.po_file


### PR DESCRIPTION
The primary change is closing issue 186: allowing for searching for plural strings, both in the original and translation.

Also included are two minor changes:
* HTML-encoding ampersands in the template
* stop showing "None" in the search input if there was no search query submitted

### All Submissions:

- [X] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [X] I have added or updated a test to cover the changes proposed in this Pull Request
- [X] I have updated the documentation to cover the changes proposed in this Pull Request