### PR TITLE
Avoid UnicodeEncodeError when quering strings

### DIFF
--- a/rosetta/tests/tests.py
+++ b/rosetta/tests/tests.py
@@ -3,6 +3,12 @@ import filecmp
 import hashlib
 import os
 import shutil
+try:
+    # Python 3
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2
+    from urllib import urlencode
 
 from django.conf import settings
 from django.dispatch import receiver
@@ -15,6 +21,7 @@ from django.http import Http404
 from django.test import TestCase, RequestFactory
 from django.test.client import Client
 from django import VERSION
+from django.utils.encoding import force_bytes
 import six
 
 from rosetta.conf import settings as rosetta_settings
@@ -966,6 +973,15 @@ class RosettaTestCase(TestCase):
         # Search msgstr[1]
         r = self.client.get(url % 'tchildren')
         self.assertContains(r, 'Child')
+
+    def test_46_search_string_with_unicode_symbols(self):
+        """Confirm that search works with unicode symbols
+        """
+        url = self.xx_form_url + '?' + urlencode({'query': force_bytes(u'Лорем')})
+
+        # It shouldn't raise
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
 
 
 # Stubbed access control function


### PR DESCRIPTION
In Python 2 if you query for text with unicode symbols,
an UnicodeEncodeError is raised.
It's because urlencode is called on unicode string.
urlencode should be called on encode strings in Python 2.
The fix is to use Django's force_bytes unility function
to pass encoded string (bytestring in Python 3) to urlencode.

### All Submissions:

- [*] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [*] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request
