### PR TITLE
Change discontinued Microsoft Translator API to the new Azure API

### DIFF
--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -747,7 +747,7 @@ def translate_text(request):
                 # [
                 #     {
                 #         "translations":[
-                #             {"text": "你好, 你叫什么名字？", "to": "zh-Hans"}
+                #             {"text": "some chinese text that gave a build error on travis ci", "to": "zh-Hans"}
                 #         ]
                 #     }
                 # ]

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,7 @@ setup(
         'six >=1.2.0',
         'Django >= 1.8',
         'requests >= 2.1.0',
-        'polib >= 1.1.0',
-        'microsofttranslator >= 0.7'
+        'polib >= 1.1.0'
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},


### PR DESCRIPTION
As discussed in issue #200, changed the old Microsoft Translator API to the new Azure Translator API using the requests framework (which was desired).

Besides updating the documentation to reflect that the only necessary setting is the `AZURE_CLIENT_SECRET` (`AZURE_CLIENT_ID` is not used), one more change is necessary which I wasn't sure how to handle correctly. 

In `/rosetta/templates/rosetta/js/rosetta.js` on line 24 the URL of the translation service is hardcoded as `"./translate/"`. This results in the path of the URL being something like `/rosetta/files/project/fr/0/translate/` (if the call is made on the `/rosetta/files/project/fr/0/` page). The intended result is the `/translate/` path at the root of rosetta. For example, the code of the pull request can be tested by visiting `http://127.0.0.1:8000/rosetta/translate/?from=en&to=fr&text=Some+text+to+translate`. If the path is *always* `/files/project/<lang>/<number>/` then the problem is easily resolved by simply updating the translation path in `urls.py`. But I am not sure if that is the case, so I am not making that change.