### PR TITLE
Allow overriding rosetta login url.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -21,6 +21,7 @@ Rosetta can be configured via the following parameters, to be defined in your pr
 * ``ROSETTA_AUTO_COMPILE``: Determines whether the MO file is automatically compiled when the PO file is saved. Defaults to ``True``.
 * ``ROSETTA_ENABLE_REFLANG``: Enables a selector for picking a reference language other than English. Defaults to ``False``.
 * ``ROSETTA_SHOW_AT_ADMIN_PANEL``: Adds a handy link to Rosetta at the bottom of the Django admin apps index. Defaults to ``False``.
+* ``ROSETTA_LOGIN_URL``: Use this if you want to override the login URL for rosetta. Defaults to ``settings.LOGIN_URL``.
 
 Storages
 --------

--- a/rosetta/conf/settings.py
+++ b/rosetta/conf/settings.py
@@ -86,3 +86,6 @@ ROSETTA_LANGUAGE_GROUPS = getattr(settings, 'ROSETTA_LANGUAGE_GROUPS', False)
 AUTO_COMPILE = getattr(settings, 'ROSETTA_AUTO_COMPILE', True)
 
 SHOW_AT_ADMIN_PANEL = getattr(settings, 'ROSETTA_SHOW_AT_ADMIN_PANEL', False)
+
+# Use this if you want to override the login URL for rosetta.
+LOGIN_URL = getattr(settings, 'ROSETTA_LOGIN_URL', settings.LOGIN_URL)

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -42,7 +42,7 @@ def get_app_name(path):
 
 
 @method_decorator(never_cache, 'dispatch')
-@method_decorator(user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL), 'dispatch')
+@method_decorator(user_passes_test(lambda user: can_translate(user), rosetta_settings.LOGIN_URL), 'dispatch')
 class RosettaBaseMixin(object):
     """A mixin class for Rosetta's class-based views. It provides:
     * security (see class decorators)
@@ -657,7 +657,7 @@ class TranslationFileDownload(RosettaFileLevelMixin, View):
             )
 
 
-@user_passes_test(lambda user: can_translate(user), settings.LOGIN_URL)
+@user_passes_test(lambda user: can_translate(user), rosetta_settings.LOGIN_URL)
 def translate_text(request):
 
     def translate(text, from_language, to_language, subscription_key):


### PR DESCRIPTION
The usecase (for me) is that I want django rosetta login URL to point to django's admin login URL.

* Added a settings variable ``ROSETTA_LOGIN_URL`` that allows to
  override the login URL for rosetta.
* No test is included because it is not possible to override this
  particular setting variable due to how tests are organized (top level
  import of rosetta_settings).

### All Submissions:

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request: **No, see commit log**
- [x] I have updated the documentation to cover the changes proposed in this Pull Request
