### PR TITLE
Strip code tag from Yandex response.

### DIFF
--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -64,7 +64,7 @@ google.setOnLoadCallback(function() {
             dataType: 'jsonp',
             success: function(response) {
                 if (response.code == 200) {
-                    trans.val(response.text[0].replace(/<br>/g, '\n').replace(/&lt;/g, '<').replace(/&gt;/g, '>'));
+                    trans.val(response.text[0].replace(/<br>/g, '\n').replace(/<\/?code>/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>'));
                     a.hide();
                 } else {
                     a.text(response);


### PR DESCRIPTION
When getting a translation suggestion for a message that contains string replacements (like `%(foo)s`), Yandex wraps string replacements in annoying `<code>` tags, this commit strips those tags automatically.

### All Submissions:

- [ ] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request
