### PR TITLE
Optional line number in the occurrences column

### DIFF
--- a/rosetta/templates/rosetta/form.html
+++ b/rosetta/templates/rosetta/form.html
@@ -130,7 +130,7 @@
                             </td>
                             <td class="location">
                                 {% for fn,lineno in message.occurrences %}
-                                    <code{% if forloop.counter|gt:"3" %} class="hide"{% endif %}>{{ fn }}:{{lineno}}</code>
+                                    <code{% if forloop.counter|gt:"3" %} class="hide"{% endif %}>{{ fn }}{% if lineno %}:{{lineno}}{% endif %}</code>
                                 {% endfor %}
                                 {% if message.occurrences|length|gt:"3" %}
                                     <a href="#">&hellip; ({% blocktrans count message.occurrences|length|minus:"3" as more_count %}{{more_count}} more{% plural %}{{more_count}} more{% endblocktrans %})</a>


### PR DESCRIPTION
Useful when the line number is omitted in the comment lines in language 
files using makemessages with --add-location=file.
https://docs.djangoproject.com/en/stable/ref/django-admin/#cmdoption-makemessages-add-location

### All Submissions:

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
