### PR TITLE
Allow passing a function itself to the setting ROSETTA_ACCESS_CONTROL…

### DIFF
--- a/rosetta/access.py
+++ b/rosetta/access.py
@@ -15,13 +15,18 @@ def get_access_control_function():
     Return a predicate for determining if a user can
     access the Rosetta views
     """
-    fn_path = getattr(settings, 'ROSETTA_ACCESS_CONTROL_FUNCTION', None)
-    if fn_path is None:
+    access_function = getattr(settings, 'ROSETTA_ACCESS_CONTROL_FUNCTION', None)
+    if access_function is None:
         return is_superuser_staff_or_in_translators_group
-    # Dynamically load a permissions function
-    perm_module, perm_func = fn_path.rsplit('.', 1)
-    perm_module = importlib.import_module(perm_module)
-    return getattr(perm_module, perm_func)
+    elif isinstance(access_function, str):
+        # Dynamically load a permissions function
+        perm_module, perm_func = access_function.rsplit('.', 1)
+        perm_module = importlib.import_module(perm_module)
+        return getattr(perm_module, perm_func)
+    elif callable(access_function):
+        return access_function
+    else:
+        raise TypeError(access_function)
 
 
 # Default access control test

--- a/rosetta/tests/tests.py
+++ b/rosetta/tests/tests.py
@@ -543,8 +543,15 @@ class RosettaTestCase(TestCase):
         response = self.client.get(self.project_file_list_url)
         self.assertEqual(200, response.status_code)
 
-        # Now replace access control, and check we get redirected
+        # Now replace access control with a function reference,
+        # and check we get redirected
         with self.settings(ROSETTA_ACCESS_CONTROL_FUNCTION='rosetta.tests.no_access'):
+            response = self.client.get(self.project_file_list_url)
+            self.assertEqual(302, response.status_code)
+
+        # Now replace access control with a function itself,
+        # and check we get redirected
+        with self.settings(ROSETTA_ACCESS_CONTROL_FUNCTION=lambda user: False):
             response = self.client.get(self.project_file_list_url)
             self.assertEqual(302, response.status_code)
 


### PR DESCRIPTION
Allow passing a function directly (instead of a string path reference) for ROSETTA_ACCESS_CONTROL.

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [x] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

As the documentation is not specific about accepting references or direct functions, I originally assumed this was already possible. Let me know if an update to the docs is needed.