### PR TITLE
MacOS build removed from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,6 @@ matrix:
   - python: "3.7"
     env: TOX_ENV=py37-django22
     dist: xenial
-  - os: osx
-    osx_image: xcode9.4
-    language: generic
-    env: TOX_ENV=py36-django22
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install memcached; brew services start memcached; fi


### PR DESCRIPTION
Python builds [are not available on the macOS and Windows environments](https://docs.travis-ci.com/user/languages/python/), so I've just remove the macOS build to avoid [this crash](https://travis-ci.org/mbi/django-rosetta/jobs/657348372?utm_medium=notification&utm_source=github_status).
