### PR TITLE
Synchronization of onchange textareas with onclick on fuzzies checkboxes.

### DIFF
--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -124,10 +124,10 @@ google.setOnLoadCallback(function() {
         });
     });
     
-    var NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = undefined;
+    var _NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = undefined;
     $('input[type="checkbox"]').click(function() {
         if (!$(this)[0].checked) {
-            NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = $(this).attr("name");
+            _NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = $(this).attr("name");
         }
     })
     $('tbody .translation textarea').change(function (e) {
@@ -135,12 +135,12 @@ google.setOnLoadCallback(function() {
         setTimeout(function() {
             var fuzzy = self.closest('tr').find('input[type="checkbox"]');
             if (fuzzy[0].checked) {
-                if (NAME_CLICKED_FUZZY_CHECKED_CHECKBOX != fuzzy.attr("name")) {
+                if (_NAME_CLICKED_FUZZY_CHECKED_CHECKBOX != fuzzy.attr("name")) {
                     fuzzy[0].checked = false;
                     fuzzy.removeAttr('checked')
                 }
             }
-            NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = undefined;
+            _NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = undefined;
         }, 50)
     });
 });

--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -124,21 +124,23 @@ google.setOnLoadCallback(function() {
         });
     });
     
-    var _CLICK_NAME_FUZZY_CHECKED_CHECKBOX = undefined;
+    var NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = undefined;
     $('input[type="checkbox"]').click(function() {
-        _CLICK_NAME_FUZZY_CHECKED_CHECKBOX = $(this).attr("name");
+        if (!$(this)[0].checked) {
+            NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = $(this).attr("name");
+        }
     })
     $('tbody .translation textarea').change(function (e) {
         var self = $(e.target);
         setTimeout(function() {
             var fuzzy = self.closest('tr').find('input[type="checkbox"]');
             if (fuzzy[0].checked) {
-                if (_CLICK_NAME_FUZZY_CHECKED_CHECKBOX != fuzzy.attr("name")) {
+                if (NAME_CLICKED_FUZZY_CHECKED_CHECKBOX != fuzzy.attr("name")) {
                     fuzzy[0].checked = false;
                     fuzzy.removeAttr('checked')
                 }
             }
-            _CLICK_NAME_FUZZY_CHECKED_CHECKBOX = undefined;
+            NAME_CLICKED_FUZZY_CHECKED_CHECKBOX = undefined;
         }, 50)
     });
 });

--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -123,13 +123,22 @@ google.setOnLoadCallback(function() {
             }
         });
     });
-    $('tbody .translation textarea').change(function () {
-        var fuzzy = $(this).closest('tr').find('input[type="checkbox"]');
-        if(fuzzy[0].checked){
-            fuzzy[0].checked = false;
-            fuzzy.removeAttr( 'checked')
-        }
-
+    
+    var _CLICK_NAME_FUZZY_CHECKED_CHECKBOX = undefined;
+    $('input[type="checkbox"]').click(function() {
+        _CLICK_NAME_FUZZY_CHECKED_CHECKBOX = $(this).attr("name");
     })
-
+    $('tbody .translation textarea').change(function (e) {
+        var self = $(e.target);
+        setTimeout(function() {
+            var fuzzy = self.closest('tr').find('input[type="checkbox"]');
+            if (fuzzy[0].checked) {
+                if (_CLICK_NAME_FUZZY_CHECKED_CHECKBOX != fuzzy.attr("name")) {
+                    fuzzy[0].checked = false;
+                    fuzzy.removeAttr('checked')
+                }
+            }
+            _CLICK_NAME_FUZZY_CHECKED_CHECKBOX = undefined;
+        }, 50)
+    });
 });


### PR DESCRIPTION
### All Submissions:

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

______________________________________________________

#### BEFORE
Before this pull, when I click on the checked checkbox after change the textarea input of a fuzzy entry, the checkbox is marked again, as you can see in the next GIF:

![rosetta-before](https://user-images.githubusercontent.com/23049315/80311653-38e2cb00-87e1-11ea-9fb1-d632362554db.gif)

#### AFTER
So I've added a synchronization mechanism between `onclick` events on checkboxes and their correspondent textareas `onchange` events adding a delay of 50 miliseconds inside `onchange` events. This is the behaviour after this pull:

![rosetta-after](https://user-images.githubusercontent.com/23049315/80311719-895a2880-87e1-11ea-8ae1-cecee91d5377.gif)

Of course, `onchange` events of textareas keep working as before.