### PR TITLE
Remove 'providing_args' kwarg from signals instanciations

### DIFF
--- a/rosetta/signals.py
+++ b/rosetta/signals.py
@@ -1,9 +1,4 @@
 from django import dispatch
 
-entry_changed = dispatch.Signal(
-    providing_args=["user", "old_msgstr", "old_fuzzy", "pofile", "language_code"]
-)
-
-post_save = dispatch.Signal(
-    providing_args=["language_code", "request"]
-)
+entry_changed = dispatch.Signal()
+post_save = dispatch.Signal()


### PR DESCRIPTION
### All Submissions:

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

This removes the kwarg `providing_args` from `dispatch.Signal` instanciations because they are not doing nothing (only document passed arguments), and will be removed in Django v4, to prevent next warning:

```
rosetta/signals.py:3: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
    entry_changed = dispatch.Signal(
```

Let me know if you want to maintain the list in a comment, but seems to me that these signals should be documented instead.