### PR TITLE
Add extra styles block to the base template

### DIFF
--- a/rosetta/templates/rosetta/base.html
+++ b/rosetta/templates/rosetta/base.html
@@ -7,10 +7,10 @@
     <link rel="stylesheet" href="{% static "admin/css/base.css" %}" type="text/css"/>
     <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" type="text/css"/>
     <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
-    {% block extra_styles %}{% endblock %}
     <style type="text/css" media="screen">
         {% include 'rosetta/css/rosetta.css' %}
     </style>
+    {% block extra_styles %}{% endblock %}
     <script src="//code.jquery.com/jquery-1.12.4.min.js"></script>
     <script type="text/javascript">
         {% include 'rosetta/js/rosetta.js' %}

--- a/rosetta/templates/rosetta/base.html
+++ b/rosetta/templates/rosetta/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{% static "admin/css/base.css" %}" type="text/css"/>
     <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" type="text/css"/>
     <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
+    {% block extra_styles %}{% endblock %}
     <style type="text/css" media="screen">
         {% include 'rosetta/css/rosetta.css' %}
     </style>


### PR DESCRIPTION
We had to remove the dark mode after upgrading to Django 3.2 by adding a new stylesheet that overrides dark mode values.
As rosetta is not fetching extra styles added to the overridden Django admin base template we had to copy the whole base.html content and add a link to the stylesheet. It would be easier to have a separate block for it so we can avoid issues when rosetta get updated.
