### PR TITLE
Remove Django4.0 depreciation warning

### DIFF
--- a/rosetta/__init__.py
+++ b/rosetta/__init__.py
@@ -1,6 +1,4 @@
 VERSION = (0, 9, 7)
-default_app_config = "rosetta.apps.RosettaAppConfig"
-
 
 def get_version(limit=3):
     """Return the version as a human-format string."""


### PR DESCRIPTION
Django 3.2 introduced an automatic AppConfig discovery.
With automatic AppConfig discovery, default_app_config is no longer needed.
As a consequence, it’s deprecated.
This removes the default_app_config line in order to remove the warning.

### All Submissions:

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request
