### PR TITLE
Loop DeepL suggestions through the backend

### DIFF
--- a/rosetta/templates/rosetta/js/rosetta.js
+++ b/rosetta/templates/rosetta/js/rosetta.js
@@ -10,40 +10,7 @@ $(document).ready(function() {
 
 
 {% if rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS %}
-    {% if rosetta_settings.DEEPL_AUTH_KEY %}
-
-        $('a.suggest').click(function(e){
-            e.preventDefault();
-            var a = $(this);
-            var str = a.html();
-            var orig = $('.original .message', a.parents('tr')).html();
-            var trans=$('textarea',a.parent());
-            var apiUrl = "https://api-free.deepl.com/v2/translate";
-            {% if deepl_language_code %}
-                var destLangRoot = '{{ deepl_language_code }}';
-            {% else %}
-                var destLangRoot = '{{ rosetta_i18n_lang_code_normalized }}'.substring(0, 2);
-            {% endif %}
-            var sourceLang = '{{ rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE }}'.substring(0, 2);
-            let authKey = '{{ rosetta_settings.DEEPL_AUTH_KEY }}:fx';
-
-            a.attr('class','suggesting').html('...');
-            fetch(apiUrl, {
-                method: 'POST',
-                headers: {
-                    "Content-Type": "application/x-www-form-urlencoded"
-                },
-                body: `auth_key=${authKey}&text=${orig}&source_lang=${sourceLang}&target_lang=${destLangRoot}`
-                }).then(response => {
-                    if(response.ok) {
-                        return response.json();
-                    }
-                }).then(data => {
-                    trans.val(data.translations[0].text.replace(/<br>/g, '\n').replace(/<\/?code>/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>'));
-                })
-                .catch(error => console.log(error));
-        });
-    {% elif rosetta_settings.AZURE_CLIENT_SECRET or rosetta_settings.GOOGLE_APPLICATION_CREDENTIALS_PATH %}
+    {% if rosetta_settings.AZURE_CLIENT_SECRET or rosetta_settings.GOOGLE_APPLICATION_CREDENTIALS_PATH or rosetta_settings.DEEPL_AUTH_KEY %}
     $('a.suggest').click(function(e){
         e.preventDefault();
         var a = $(this);

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
 [testenv:gettext]
 basepython = python3
 changedir = rosetta/locale/
-whitelist_externals =
+allowlist_externals =
       msgfmt
 
 commands =


### PR DESCRIPTION
DeepL wants an Authorization header but we cannot set this in the JavaScript code because of missing CORS headers on the DeepL side.

Opening as a draft pull request because this change introduces a different way to fetch suggestions from third party services.

### All Submissions:

- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request
- [ ] I have updated the documentation to cover the changes proposed in this Pull Request
