### PR TITLE
Correct link to polib library

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,4 +38,4 @@ By default Rosetta hides its own catalog files in the file selection interface (
 Acknowledgments
 ***************
 
-* Rosetta uses the excellent `polib <https://bitbucket.org/izi/polib>`_ library to parse and handle gettext files.
+* Rosetta uses the excellent `polib <https://pypi.org/project/polib/>`_ library to parse and handle gettext files.


### PR DESCRIPTION
The current link to polib https://bitbucket.org/izi/polib seems dead
