### PR TITLE
Content-Security-Policy compatibility

### DIFF
--- a/rosetta/static/admin/rosetta/css/rosetta.css
+++ b/rosetta/static/admin/rosetta/css/rosetta.css
@@ -1,4 +1,4 @@
-{% load static %}
+
 #user-tools p span { margin-left:2em; }
 table{width:100%;}
 td.translation label {font-size: 95%;}
@@ -24,7 +24,7 @@ th.c,td.c {text-align: center;}
 td.original code {font-size:90%; padding: 0 1px; }
 tr.row2 td.original code {background-color:#FFB2A5; padding: 0 0.3em;}
 tr.row1 td.original code {background-color:#FFB2A5;}
-.alert { font-weight:bold;padding:4px 5px 4px 25px; margin-left:1em; color: red; background:transparent url({% static 'admin/img/icon-alert.svg' %}) 5px .3em no-repeat; }
+.alert { font-weight:bold;padding:4px 5px 4px 25px; margin-left:1em; color: red; background:transparent url(data:image/svg+xml,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20fill%3D%22%23efb80b%22%20d%3D%22M1024%201375v-190q0-14-9.5-23.5t-22.5-9.5h-192q-13%200-22.5%209.5t-9.5%2023.5v190q0%2014%209.5%2023.5t22.5%209.5h192q13%200%2022.5-9.5t9.5-23.5zm-2-374l18-459q0-12-10-19-13-11-24-11h-220q-11%200-24%2011-10%207-10%2021l17%20457q0%2010%2010%2016.5t24%206.5h185q14%200%2023.5-6.5t10.5-16.5zm-14-934l768%201408q35%2063-2%20126-17%2029-46.5%2046t-63.5%2017h-1536q-34%200-63.5-17t-46.5-46q-37-63-2-126l768-1408q17-31%2047-49t65-18%2065%2018%2047%2049z%22%2F%3E%0A%3C%2Fsvg%3E%0A) 5px .3em no-repeat; }
 p.errornote { margin-top:0.4em;}
 #footer { clear:both; color:#999; font-size:9px; margin:0 6px; text-align:left;}
 #changelist table tbody td:first-child, #changelist table thead th:first-child  {text-align: left;}
@@ -48,4 +48,7 @@ div.module {margin-bottom: 20px;}
     padding: 1px 5px;
     border-radius: 10px;
     font-size: 11px;
+}
+#action-toggle {
+    display: inline;
 }

--- a/rosetta/static/admin/rosetta/js/rosetta.js
+++ b/rosetta/static/admin/rosetta/js/rosetta.js
@@ -1,4 +1,4 @@
-{% load rosetta %}
+const rosetta_settings = JSON.parse(document.getElementById('rosetta-settings-js').textContent);
 
 $(document).ready(function() {
 
@@ -8,21 +8,21 @@ $(document).ready(function() {
         $('.hide', $(this).parent()).hide();
     });
 
-{% if rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS %}
-    {% if rosetta_settings.DEEPL_AUTH_KEY or rosetta_settings.AZURE_CLIENT_SECRET or rosetta_settings.GOOGLE_APPLICATION_CREDENTIALS_PATH %}
+  if (rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS) {
+    if (rosetta_settings.server_auth_key) {
     $('a.suggest').click(function(e){
         e.preventDefault();
         var a = $(this);
         var str = a.html();
         var orig = $('.original .message', a.parents('tr')).html();
         var trans=$('textarea',a.parent());
-        var sourceLang = '{{ rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE }}';
-        var destLang = '{{ rosetta_i18n_lang_code_normalized }}';
+        var sourceLang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE;
+        var destLang = rosetta_settings.rosetta_i18n_lang_code_normalized;
 
         orig = unescape(orig).replace(/<br\s?\/?>/g,'\n').replace(/<code>/,'').replace(/<\/code>/g,'').replace(/&gt;/g,'>').replace(/&lt;/g,'<');
         a.attr('class','suggesting').html('...');
 
-        $.getJSON("{% url 'rosetta.translate_text' %}", {
+        $.getJSON(rosetta_settings.translate_text_url, {
                 from: sourceLang,
                 to: destLang,
                 text: orig,
@@ -37,7 +37,7 @@ $(document).ready(function() {
             }
         );
     });
-   {% elif rosetta_settings.YANDEX_TRANSLATE_KEY %}
+  } else if (rosetta_settings.YANDEX_TRANSLATE_KEY) {
     $('a.suggest').click(function(e){
         e.preventDefault();
         var a = $(this);
@@ -45,8 +45,8 @@ $(document).ready(function() {
         var orig = $('.original .message', a.parents('tr')).html();
         var trans=$('textarea',a.parent());
         var apiUrl = "https://translate.yandex.net/api/v1.5/tr.json/translate";
-        var destLangRoot = '{{ rosetta_i18n_lang_code }}'.split('-')[0];
-        var lang = '{{ rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE }}-' + destLangRoot;
+        var destLangRoot = rosetta_settings.rosetta_i18n_lang_code.split('-')[0];
+        var lang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE + '-' + destLangRoot;
 
         a.attr('class','suggesting').html('...');
 
@@ -54,7 +54,7 @@ $(document).ready(function() {
             error: 'onTranslationError',
             success: 'onTranslationComplete',
             lang: lang,
-            key: '{{ rosetta_settings.YANDEX_TRANSLATE_KEY }}',
+            key: rosetta_settings.YANDEX_TRANSLATE_KEY,
             format: 'html',
             text: orig
         };
@@ -76,8 +76,8 @@ $(document).ready(function() {
             }
         });
     });
-   {% endif %}
-{% endif %}
+  }
+  }
 
     $('td.plural').each(function(i) {
         var td = $(this), trY = parseInt(td.closest('tr').offset().top);

--- a/rosetta/templates/rosetta/base.html
+++ b/rosetta/templates/rosetta/base.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>{% load static %}
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'self';" />
     <title>{% block pagetitle %}Rosetta{% endblock %}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
     <link rel="stylesheet" href="{% static "admin/css/base.css" %}" type="text/css"/>
     <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" type="text/css"/>
     <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
-    <style type="text/css" media="screen">
-        {% include 'rosetta/css/rosetta.css' %}
-    </style>
+    <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
+    <link rel="stylesheet" href="{% static "admin/rosetta/css/rosetta.css" %}" type="text/css"/>
     {% block extra_styles %}{% endblock %}
     <script src="{% static "admin/js/vendor/jquery/jquery.min.js" %}"></script>
-    <script type="text/javascript">
-        {% include 'rosetta/js/rosetta.js' %}
-    </script>
+    {{ rosetta_settings_js|json_script:"rosetta-settings-js" }}
+    <script src="{% static "admin/rosetta/js/rosetta.js" %}"></script>
 </head>
 <body>
     <div id="container">

--- a/rosetta/templates/rosetta/form.html
+++ b/rosetta/templates/rosetta/form.html
@@ -9,9 +9,6 @@
             <a href="{% url 'rosetta-download-file' po_filter=po_filter lang_id=lang_id idx=idx %}">{% trans "Download this catalog" %}</a></span>
         </p>
     </div>
-    <script type="text/javascript">
-    </script>
-
 {% endblock %}
 
 {% block pagetitle %}{{block.super}} - {{rosetta_settings.MESSAGES_SOURCE_LANGUAGE_NAME}} - {{rosetta_i18n_lang_name}} ({{ rosetta_i18n_pofile.percent_translated }}%){% endblock %}
@@ -75,7 +72,7 @@
                         <th><div class="text">{% trans "Original" %}</div></th>
                         {% if main_language %}<th>{{ main_language }}</th>{% endif %}
                         <th>{{ rosetta_i18n_lang_name }}</th>
-                        <th class="info-tip c" title="{% trans "Fuzzy entries call for revision by the translator." %}"><input style="display: inline;" id="action-toggle" type="checkbox"> {% trans "Fuzzy" %}</th>
+                        <th class="info-tip c" title="{% trans "Fuzzy entries call for revision by the translator." %}"><input id="action-toggle" type="checkbox"> {% trans "Fuzzy" %}</th>
                         {% if rosetta_settings.SHOW_OCCURRENCES %}<th>{% trans "Occurrences(s)" %}</th>{% endif %}
                     </tr>
                 </thead>

--- a/rosetta/views.py
+++ b/rosetta/views.py
@@ -520,11 +520,26 @@ class TranslationFormView(RosettaFileLevelMixin, TemplateView):
             {k: v for k, v in query_string_args.items() if k == "ref_lang"}
         )
 
+        rosetta_settings_js = {
+            "ENABLE_TRANSLATION_SUGGESTIONS": rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS,
+            "MESSAGES_SOURCE_LANGUAGE_CODE": rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE,
+            "YANDEX_TRANSLATE_KEY": rosetta_settings.YANDEX_TRANSLATE_KEY,
+            "rosetta_i18n_lang_code": self.language_id,
+            "translate_text_url": reverse("rosetta.translate_text"),
+            "rosetta_i18n_lang_code_normalized ": self.language_id.replace("_", "-"),
+            "server_auth_key": bool(
+                rosetta_settings.DEEPL_AUTH_KEY
+                or rosetta_settings.AZURE_CLIENT_SECRET
+                or rosetta_settings.GOOGLE_APPLICATION_CREDENTIALS_PATH
+            ),
+        }
+
         context.update(
             {
                 "version": get_rosetta_version(),
                 "LANGUAGES": LANGUAGES,
                 "rosetta_settings": rosetta_settings,
+                "rosetta_settings_js": rosetta_settings_js,
                 "rosetta_i18n_lang_name": rosetta_i18n_lang_name,
                 "rosetta_i18n_lang_code": self.language_id,
                 "rosetta_i18n_lang_code_normalized": self.language_id.replace("_", "-"),


### PR DESCRIPTION
**Summary of Changes:**

- Convert `admin/img/icon-alert.svg` to a data URI to avoid referencing static files in CSS.
- Convert `rosetta.css` to a proper CSS file and move it to the static folder.
- Pass required variables for JavaScript through the `rosetta_settings_js` context variable. `rosetta_settings_js` contains relevant settings and variables for JavaScript.
- Convert `rosetta.js` to a proper JS file and move it to the static folder. 
- Move inline style for `action-toggle` to the stylesheet file.


ref: https://github.com/mbi/django-rosetta/issues/287




### All Submissions:

- [X] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [ ] I have added or updated a test to cover the changes proposed in this Pull Request

No

- [ ] I have updated the documentation to cover the changes proposed in this Pull Request

No
