### PR TITLE
Auto-format css/js/html and add eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+    extends: "eslint:recommended",
+    env: {
+        browser: true,
+        node: true,
+    },
+    parserOptions: { ecmaVersion: 9 },
+    globals: {
+        $: "readonly",
+    },
+};

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,19 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+
+-   repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+    - id: eslint
+
+-   repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+    - id: prettier
+      types_or: [css, javascript]
+
+-   repo: https://github.com/rtts/djhtml
+    rev: 3.0.6
+    hooks:
+    - id: djhtml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "printWidth": 100,
+    "tabWidth": 4
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 # serve to show the default.
 
 import os
-import shlex
 import sys
 
 

--- a/rosetta/static/admin/rosetta/css/rosetta.css
+++ b/rosetta/static/admin/rosetta/css/rosetta.css
@@ -1,47 +1,147 @@
-
-#user-tools p span { margin-left:2em; }
-table{width:100%;}
-td.translation label {font-size: 95%;}
-td.translation textarea, td.original { font-size:110%;}
-td.translation,td.original {width:30%;}
-td.original .plural-container { position:relative}
-td .context,td.original .message {display:block;}
-td .context { margin-top: 1rem; color: #999; }
-td.translation textarea{ width:98.5%; min-height:25px; margin:2px 0; }
-.rtl td.translation textarea { direction: rtl;}
-.plural span {display:block; margin:2px 0; position:absolute}
-td.location code,td.location a { font-size:95%; display:block;}
-td.location code.hide { display:none;}
-.submit-row {margin-bottom:0;}
-li.nobubble,li.nobubble:hover { background-image:none;}
-.object-tools li.active, .object-tools li.active a { color:yellow;}
-p.paginator input { float:right;}
-p.paginator span.space { margin: 0 0.5em;}
-.paginator {text-align:left; border:none; background:transparent; }
-.paginator strong { margin-left:1em;}
-th.r,td.r {text-align:right;}
-th.c,td.c {text-align: center;}
-td.original code {font-size:90%; padding: 0 1px; }
-tr.row2 td.original code {background-color:#FFB2A5; padding: 0 0.3em;}
-tr.row1 td.original code {background-color:#FFB2A5;}
-.alert { font-weight:bold;padding:4px 5px 4px 25px; margin-left:1em; color: red; background:transparent url(data:image/svg+xml,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20fill%3D%22%23efb80b%22%20d%3D%22M1024%201375v-190q0-14-9.5-23.5t-22.5-9.5h-192q-13%200-22.5%209.5t-9.5%2023.5v190q0%2014%209.5%2023.5t22.5%209.5h192q13%200%2022.5-9.5t9.5-23.5zm-2-374l18-459q0-12-10-19-13-11-24-11h-220q-11%200-24%2011-10%207-10%2021l17%20457q0%2010%2010%2016.5t24%206.5h185q14%200%2023.5-6.5t10.5-16.5zm-14-934l768%201408q35%2063-2%20126-17%2029-46.5%2046t-63.5%2017h-1536q-34%200-63.5-17t-46.5-46q-37-63-2-126l768-1408q17-31%2047-49t65-18%2065%2018%2047%2049z%22%2F%3E%0A%3C%2Fsvg%3E%0A) 5px .3em no-repeat; }
-p.errornote { margin-top:0.4em;}
-#footer { clear:both; color:#999; font-size:9px; margin:0 6px; text-align:left;}
-#changelist table tbody td:first-child, #changelist table thead th:first-child  {text-align: left;}
-td.hint {color: #777;}
-div.module {margin-bottom: 20px;}
-.checkall {cursor:pointer}
-#toolbar { height:20px}
-#toolbar #translate-all { float:right}
-#toolbar form { float:left; }
-#changelist table thead th { padding: 2px 5px; }
+#user-tools p span {
+    margin-left: 2em;
+}
+table {
+    width: 100%;
+}
+td.translation label {
+    font-size: 95%;
+}
+td.translation textarea,
+td.original {
+    font-size: 110%;
+}
+td.translation,
+td.original {
+    width: 30%;
+}
+td.original .plural-container {
+    position: relative;
+}
+td .context,
+td.original .message {
+    display: block;
+}
+td .context {
+    margin-top: 1rem;
+    color: #999;
+}
+td.translation textarea {
+    width: 98.5%;
+    min-height: 25px;
+    margin: 2px 0;
+}
+.rtl td.translation textarea {
+    direction: rtl;
+}
+.plural span {
+    display: block;
+    margin: 2px 0;
+    position: absolute;
+}
+td.location code,
+td.location a {
+    font-size: 95%;
+    display: block;
+}
+td.location code.hide {
+    display: none;
+}
+.submit-row {
+    margin-bottom: 0;
+}
+li.nobubble,
+li.nobubble:hover {
+    background-image: none;
+}
+.object-tools li.active,
+.object-tools li.active a {
+    color: yellow;
+}
+p.paginator input {
+    float: right;
+}
+p.paginator span.space {
+    margin: 0 0.5em;
+}
+.paginator {
+    text-align: left;
+    border: none;
+    background: transparent;
+}
+.paginator strong {
+    margin-left: 1em;
+}
+th.r,
+td.r {
+    text-align: right;
+}
+th.c,
+td.c {
+    text-align: center;
+}
+td.original code {
+    font-size: 90%;
+    padding: 0 1px;
+}
+tr.row2 td.original code {
+    background-color: #ffb2a5;
+    padding: 0 0.3em;
+}
+tr.row1 td.original code {
+    background-color: #ffb2a5;
+}
+.alert {
+    font-weight: bold;
+    padding: 4px 5px 4px 25px;
+    margin-left: 1em;
+    color: red;
+    background: transparent
+        url(data:image/svg+xml,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20fill%3D%22%23efb80b%22%20d%3D%22M1024%201375v-190q0-14-9.5-23.5t-22.5-9.5h-192q-13%200-22.5%209.5t-9.5%2023.5v190q0%2014%209.5%2023.5t22.5%209.5h192q13%200%2022.5-9.5t9.5-23.5zm-2-374l18-459q0-12-10-19-13-11-24-11h-220q-11%200-24%2011-10%207-10%2021l17%20457q0%2010%2010%2016.5t24%206.5h185q14%200%2023.5-6.5t10.5-16.5zm-14-934l768%201408q35%2063-2%20126-17%2029-46.5%2046t-63.5%2017h-1536q-34%200-63.5-17t-46.5-46q-37-63-2-126l768-1408q17-31%2047-49t65-18%2065%2018%2047%2049z%22%2F%3E%0A%3C%2Fsvg%3E%0A)
+        5px 0.3em no-repeat;
+}
+p.errornote {
+    margin-top: 0.4em;
+}
+#footer {
+    clear: both;
+    color: #999;
+    font-size: 9px;
+    margin: 0 6px;
+    text-align: left;
+}
+#changelist table tbody td:first-child,
+#changelist table thead th:first-child {
+    text-align: left;
+}
+td.hint {
+    color: #777;
+}
+div.module {
+    margin-bottom: 20px;
+}
+.checkall {
+    cursor: pointer;
+}
+#toolbar {
+    height: 20px;
+}
+#toolbar #translate-all {
+    float: right;
+}
+#toolbar form {
+    float: left;
+}
+#changelist table thead th {
+    padding: 2px 5px;
+}
 
 #changelist {
-  display: block !important;
+    display: block !important;
 }
 
 .info-tip::after {
-    content: '?';
+    content: "?";
     color: white;
     background-color: #bbb;
     margin-left: 5px;

--- a/rosetta/static/admin/rosetta/js/rosetta.js
+++ b/rosetta/static/admin/rosetta/js/rosetta.js
@@ -1,140 +1,159 @@
-const rosetta_settings = JSON.parse(document.getElementById('rosetta-settings-js').textContent);
+const rosetta_settings = JSON.parse(document.getElementById("rosetta-settings-js").textContent);
 
-$(document).ready(function() {
-
-    $('.location a').show().toggle(function() {
-        $('.hide', $(this).parent()).show();
-    }, function() {
-        $('.hide', $(this).parent()).hide();
-    });
-
-  if (rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS) {
-    if (rosetta_settings.server_auth_key) {
-    $('a.suggest').click(function(e){
-        e.preventDefault();
-        var a = $(this);
-        var str = a.html();
-        var orig = $('.original .message', a.parents('tr')).html();
-        var trans=$('textarea',a.parent());
-        var sourceLang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE;
-        var destLang = rosetta_settings.rosetta_i18n_lang_code_normalized;
-
-        orig = unescape(orig).replace(/<br\s?\/?>/g,'\n').replace(/<code>/,'').replace(/<\/code>/g,'').replace(/&gt;/g,'>').replace(/&lt;/g,'<');
-        a.attr('class','suggesting').html('...');
-
-        $.getJSON(rosetta_settings.translate_text_url, {
-                from: sourceLang,
-                to: destLang,
-                text: orig,
+$(document).ready(function () {
+    $(".location a")
+        .show()
+        .toggle(
+            function () {
+                $(".hide", $(this).parent()).show();
             },
-            function(data) {
-                if (data.success){
-                    trans.val(unescape(data.translation).replace(/&#39;/g,'\'').replace(/&quot;/g,'"').replace(/%\s+(\([^\)]+\))\s*s/g,' %$1s '));
-                    a.hide();
-                } else {
-                    a.text(data.error);
-                }
-            }
+            function () {
+                $(".hide", $(this).parent()).hide();
+            },
         );
+
+    if (rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS) {
+        if (rosetta_settings.server_auth_key) {
+            $("a.suggest").click(function (e) {
+                e.preventDefault();
+                var a = $(this);
+                var str = a.html();
+                var orig = $(".original .message", a.parents("tr")).html();
+                var trans = $("textarea", a.parent());
+                var sourceLang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE;
+                var destLang = rosetta_settings.rosetta_i18n_lang_code_normalized;
+
+                orig = unescape(orig)
+                    .replace(/<br\s?\/?>/g, "\n")
+                    .replace(/<code>/, "")
+                    .replace(/<\/code>/g, "")
+                    .replace(/&gt;/g, ">")
+                    .replace(/&lt;/g, "<");
+                a.attr("class", "suggesting").html("...");
+
+                $.getJSON(
+                    rosetta_settings.translate_text_url,
+                    {
+                        from: sourceLang,
+                        to: destLang,
+                        text: orig,
+                    },
+                    function (data) {
+                        if (data.success) {
+                            trans.val(
+                                unescape(data.translation)
+                                    .replace(/&#39;/g, "'")
+                                    .replace(/&quot;/g, '"')
+                                    .replace(/%\s+(\([^\)]+\))\s*s/g, " %$1s "),
+                            );
+                            a.hide();
+                        } else {
+                            a.text(data.error);
+                        }
+                    },
+                );
+            });
+        } else if (rosetta_settings.YANDEX_TRANSLATE_KEY) {
+            $("a.suggest").click(function (e) {
+                e.preventDefault();
+                var a = $(this);
+                var str = a.html();
+                var orig = $(".original .message", a.parents("tr")).html();
+                var trans = $("textarea", a.parent());
+                var apiUrl = "https://translate.yandex.net/api/v1.5/tr.json/translate";
+                var destLangRoot = rosetta_settings.rosetta_i18n_lang_code.split("-")[0];
+                var lang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE + "-" + destLangRoot;
+
+                a.attr("class", "suggesting").html("...");
+
+                var apiData = {
+                    error: "onTranslationError",
+                    success: "onTranslationComplete",
+                    lang: lang,
+                    key: rosetta_settings.YANDEX_TRANSLATE_KEY,
+                    format: "html",
+                    text: orig,
+                };
+
+                $.ajax({
+                    url: apiUrl,
+                    data: apiData,
+                    dataType: "jsonp",
+                    success: function (response) {
+                        if (response.code == 200) {
+                            trans.val(
+                                response.text[0]
+                                    .replace(/<br>/g, "\n")
+                                    .replace(/<\/?code>/g, "")
+                                    .replace(/&lt;/g, "<")
+                                    .replace(/&gt;/g, ">"),
+                            );
+                            a.hide();
+                        } else {
+                            a.text(response);
+                        }
+                    },
+                    error: function (response) {
+                        a.text(response);
+                    },
+                });
+            });
+        }
+    }
+
+    $("td.plural").each(function (i) {
+        var td = $(this);
+        var trY = parseInt(td.closest("tr").offset().top);
+        $("textarea", $(this).closest("tr")).each(function (j) {
+            var textareaY = parseInt($(this).offset().top) - trY;
+            $($(".part", td).get(j)).css("top", textareaY + "px");
+        });
     });
-  } else if (rosetta_settings.YANDEX_TRANSLATE_KEY) {
-    $('a.suggest').click(function(e){
-        e.preventDefault();
-        var a = $(this);
-        var str = a.html();
-        var orig = $('.original .message', a.parents('tr')).html();
-        var trans=$('textarea',a.parent());
-        var apiUrl = "https://translate.yandex.net/api/v1.5/tr.json/translate";
-        var destLangRoot = rosetta_settings.rosetta_i18n_lang_code.split('-')[0];
-        var lang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE + '-' + destLangRoot;
 
-        a.attr('class','suggesting').html('...');
+    $(".translation textarea")
+        .blur(function () {
+            if ($(this).val()) {
+                $(".alert", $(this).parents("tr")).remove();
+                var RX = /%(?:\([^\s\)]*\))?[sdf]|\{[\w\d_]+?\}/g;
+                var origs = $(this).parents("tr").find(".original span").html().match(RX);
+                var trads = $(this).val().match(RX);
+                var error = $('<span class="alert">Unmatched variables</span>');
 
-        var apiData = {
-            error: 'onTranslationError',
-            success: 'onTranslationComplete',
-            lang: lang,
-            key: rosetta_settings.YANDEX_TRANSLATE_KEY,
-            format: 'html',
-            text: orig
-        };
-
-        $.ajax({
-            url: apiUrl,
-            data: apiData,
-            dataType: 'jsonp',
-            success: function(response) {
-                if (response.code == 200) {
-                    trans.val(response.text[0].replace(/<br>/g, '\n').replace(/<\/?code>/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>'));
-                    a.hide();
+                if (origs && trads) {
+                    for (var i = trads.length; i--; ) {
+                        var key = trads[i];
+                        if (-1 == $.inArray(key, origs)) {
+                            $(this).before(error);
+                            return false;
+                        }
+                    }
+                    return true;
                 } else {
-                    a.text(response);
-                }
-            },
-            error: function(response) {
-                a.text(response);
-            }
-        });
-    });
-  }
-  }
-
-    $('td.plural').each(function(i) {
-        var td = $(this), trY = parseInt(td.closest('tr').offset().top);
-        $('textarea', $(this).closest('tr')).each(function(j) {
-            var textareaY=  parseInt($(this).offset().top) - trY;
-            $($('.part',td).get(j)).css('top',textareaY + 'px');
-        });
-    });
-
-    $('.translation textarea')
-
-    .blur(function() {
-        if($(this).val()) {
-            $('.alert', $(this).parents('tr')).remove();
-            var RX = /%(?:\([^\s\)]*\))?[sdf]|\{[\w\d_]+?\}/g,
-                origs=$(this).parents('tr').find('.original span').html().match(RX),
-                trads=$(this).val().match(RX),
-                error = $('<span class="alert">Unmatched variables</span>');
-
-            if (origs && trads) {
-                for (var i = trads.length; i--;){
-                    var key = trads[i];
-                    if (-1 == $.inArray(key, origs)) {
-                        $(this).before(error)
+                    if (!(origs === null && trads === null)) {
+                        $(this).before(error);
                         return false;
                     }
                 }
                 return true;
-            } else {
-                if (!(origs === null && trads === null)) {
-                    $(this).before(error);
-                    return false;
-                }
             }
-            return true;
-        }
-    })
+        })
+        .keyup(function () {
+            var cb = $(this).parents("tr").find('td.c input[type="checkbox"]');
+            if (cb.is(":checked")) {
+                cb[0].checked = false;
+                cb.removeAttr("checked");
+            }
+        })
+        .eq(0)
+        .focus();
 
-    .keyup(function () {
-        var cb = $(this).parents('tr').find('td.c input[type="checkbox"]');
-        if(cb.is(':checked')){
-            cb[0].checked = false;
-            cb.removeAttr( 'checked')
-        }
-
-    })
-
-    .eq(0).focus();
-
-    $('#action-toggle').change(function(){
-        jQuery('tbody td.c input[type="checkbox"]').each(function(i, e) {
-            if($('#action-toggle').is(':checked')) {
-                $(e).attr('checked', 'checked');
+    $("#action-toggle").change(function () {
+        $('tbody td.c input[type="checkbox"]').each(function (i, e) {
+            if ($("#action-toggle").is(":checked")) {
+                $(e).attr("checked", "checked");
             } else {
-                $(e).removeAttr('checked');
+                $(e).removeAttr("checked");
             }
         });
     });
-
 });

--- a/rosetta/static/admin/rosetta/js/rosetta.js
+++ b/rosetta/static/admin/rosetta/js/rosetta.js
@@ -17,7 +17,6 @@ $(document).ready(function () {
             $("a.suggest").click(function (e) {
                 e.preventDefault();
                 var a = $(this);
-                var str = a.html();
                 var orig = $(".original .message", a.parents("tr")).html();
                 var trans = $("textarea", a.parent());
                 var sourceLang = rosetta_settings.MESSAGES_SOURCE_LANGUAGE_CODE;
@@ -44,7 +43,7 @@ $(document).ready(function () {
                                 unescape(data.translation)
                                     .replace(/&#39;/g, "'")
                                     .replace(/&quot;/g, '"')
-                                    .replace(/%\s+(\([^\)]+\))\s*s/g, " %$1s "),
+                                    .replace(/%\s+(\([^)]+\))\s*s/g, " %$1s "),
                             );
                             a.hide();
                         } else {
@@ -57,7 +56,6 @@ $(document).ready(function () {
             $("a.suggest").click(function (e) {
                 e.preventDefault();
                 var a = $(this);
-                var str = a.html();
                 var orig = $(".original .message", a.parents("tr")).html();
                 var trans = $("textarea", a.parent());
                 var apiUrl = "https://translate.yandex.net/api/v1.5/tr.json/translate";
@@ -101,7 +99,7 @@ $(document).ready(function () {
         }
     }
 
-    $("td.plural").each(function (i) {
+    $("td.plural").each(function () {
         var td = $(this);
         var trY = parseInt(td.closest("tr").offset().top);
         $("textarea", $(this).closest("tr")).each(function (j) {
@@ -114,7 +112,7 @@ $(document).ready(function () {
         .blur(function () {
             if ($(this).val()) {
                 $(".alert", $(this).parents("tr")).remove();
-                var RX = /%(?:\([^\s\)]*\))?[sdf]|\{[\w\d_]+?\}/g;
+                var RX = /%(?:\([^\s)]*\))?[sdf]|\{[\w\d_]+?\}/g;
                 var origs = $(this).parents("tr").find(".original span").html().match(RX);
                 var trads = $(this).val().match(RX);
                 var error = $('<span class="alert">Unmatched variables</span>');

--- a/rosetta/templates/rosetta/admin_index.html
+++ b/rosetta/templates/rosetta/admin_index.html
@@ -2,20 +2,20 @@
 {% load rosetta i18n %}
 
 {% block sidebar %}
-{{block.super}}
-{% if request.user|can_translate  %}
-<div id="rosetta-content-main">
-    <div class="app-rosetta module">
-        <table>
-        <caption>
-            <a class="section" href="{% url 'rosetta-file-list' po_filter='project' %}">Rosetta</a>
-        </caption>
-            <tbody><tr>
-                <th scope="row"><a href="{% url 'rosetta-file-list' po_filter='project' %}">{% trans "Translations" %}</a></th>
-                <td colspan="2"><a href="{% url 'rosetta-file-list' po_filter='project' %}" class="changelink">{% trans "Change" %}</a></td>
-            </tr>
-        </tbody></table>
-    </div>
-</div>
-{% endif %}
+    {{ block.super }}
+    {% if request.user|can_translate %}
+        <div id="rosetta-content-main">
+            <div class="app-rosetta module">
+                <table>
+                    <caption>
+                        <a class="section" href="{% url 'rosetta-file-list' po_filter='project' %}">Rosetta</a>
+                    </caption>
+                    <tbody><tr>
+                        <th scope="row"><a href="{% url 'rosetta-file-list' po_filter='project' %}">{% trans "Translations" %}</a></th>
+                        <td colspan="2"><a href="{% url 'rosetta-file-list' po_filter='project' %}" class="changelink">{% trans "Change" %}</a></td>
+                    </tr>
+                    </tbody></table>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/rosetta/templates/rosetta/base.html
+++ b/rosetta/templates/rosetta/base.html
@@ -1,36 +1,36 @@
 <!DOCTYPE html>{% load static %}
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'self';" />
-    <title>{% block pagetitle %}Rosetta{% endblock %}</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self';" />
+        <title>{% block pagetitle %}Rosetta{% endblock %}</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-    <link rel="stylesheet" href="{% static "admin/css/base.css" %}" type="text/css"/>
-    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" type="text/css"/>
-    <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
-    <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
-    <link rel="stylesheet" href="{% static "admin/rosetta/css/rosetta.css" %}" type="text/css"/>
-    {% block extra_styles %}{% endblock %}
-    <script src="{% static "admin/js/vendor/jquery/jquery.min.js" %}"></script>
-    {{ rosetta_settings_js|json_script:"rosetta-settings-js" }}
-    <script src="{% static "admin/rosetta/js/rosetta.js" %}"></script>
-</head>
-<body>
-    <div id="container">
-        <div id="header">
-            {% block header %}
-            <div id="branding">
-                <h1 id="site-name"><a href="{% url 'rosetta-file-list' po_filter='project' %}">Rosetta</a> </h1>
+        <link rel="stylesheet" href="{% static "admin/css/base.css" %}" type="text/css"/>
+        <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" type="text/css"/>
+        <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
+        <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}" type="text/css"/>
+        <link rel="stylesheet" href="{% static "admin/rosetta/css/rosetta.css" %}" type="text/css"/>
+        {% block extra_styles %}{% endblock %}
+        <script src="{% static "admin/js/vendor/jquery/jquery.min.js" %}"></script>
+        {{ rosetta_settings_js|json_script:"rosetta-settings-js" }}
+        <script src="{% static "admin/rosetta/js/rosetta.js" %}"></script>
+    </head>
+    <body>
+        <div id="container">
+            <div id="header">
+                {% block header %}
+                    <div id="branding">
+                        <h1 id="site-name"><a href="{% url 'rosetta-file-list' po_filter='project' %}">Rosetta</a> </h1>
+                    </div>
+                {% endblock %}
             </div>
-            {% endblock %}
+            <div class="breadcrumbs">{% block breadcumbs %}{% endblock %}</div>
+            <div id="content" class="flex">
+                {% block main %}{% endblock %}
+            </div>
+            <div id="footer" class="breadcumbs">
+                <a href="https://github.com/mbi/django-rosetta">Rosetta</a> <span class="version">{{ version }}</span>
+            </div>
         </div>
-        <div class="breadcrumbs">{% block breadcumbs %}{% endblock %}</div>
-        <div id="content" class="flex">
-            {% block main %}{% endblock %}
-        </div>
-        <div id="footer" class="breadcumbs">
-            <a href="https://github.com/mbi/django-rosetta">Rosetta</a> <span class="version">{{version}}</span>
-        </div>
-    </div>
-</body>
+    </body>
 </html>

--- a/rosetta/templates/rosetta/file-list.html
+++ b/rosetta/templates/rosetta/file-list.html
@@ -1,7 +1,7 @@
 {% extends "rosetta/base.html" %}
 {% load i18n static %}
 
-{% block pagetitle %}{{block.super}} - {% trans "Language selection" %}{% endblock %}
+{% block pagetitle %}{{ block.super }} - {% trans "Language selection" %}{% endblock %}
 
 {% block breadcumbs %}
     <div><a href="{% url 'rosetta-file-list' po_filter=po_filter %}">{% trans "Home" %}</a> &rsaquo; {% trans "Language selection" %}</div>
@@ -20,45 +20,45 @@
 
     {% if has_pos %}
 
-    {% for lid,language,pos in languages %}
-    {% if pos %}
+        {% for lid,language,pos in languages %}
+            {% if pos %}
 
-        <div class="module">
-            <h2>{{language}}</h2>
-            <table cellspacing="0">
-                <thead>
-                    <tr>
-                        <th>{% trans "Application" %}</th>
-                        <th class="r">{% trans "Progress"%}</th>
-                        <th class="r">{% trans "Messages" %}</th>
-                        <th class="r">{% trans "Translated" %}</th>
-                        <th class="info-tip r" title="{% trans "Fuzzy entries call for revision by the translator." %}">{% trans "Fuzzy"%}</th>
-                        <th class="r">{% trans "Obsolete"%}</th>
-                        <th>{% trans "File" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for app,path,po in pos %}
-                    <tr class="{% cycle 'row1' 'row2' %}">
-                        <td><a href="{% url 'rosetta-form' po_filter=po_filter lang_id=lid idx=forloop.counter0 %}">{{ app|title }}</a></td>
-                        <td class="ch-progress r">{{po.percent_translated}}%</td>
-                        {% with po.untranslated_entries|length as len_untranslated_entries %}
-                        <td class="ch-messages r">{{po.translated_entries|length|add:len_untranslated_entries}}</td>
-                        {% endwith %}
-                        <td class="ch-translated r">{{po.translated_entries|length}}</td>
-                        <td class="ch-fuzzy r">{{po.fuzzy_entries|length}}</td>
-                        <td class="ch-obsolete r">{{po.obsolete_entries|length}}</td>
-                        <td class="hint">{{ path }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
-    {% endfor %}
+                <div class="module">
+                    <h2>{{ language }}</h2>
+                    <table cellspacing="0">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Application" %}</th>
+                                <th class="r">{% trans "Progress" %}</th>
+                                <th class="r">{% trans "Messages" %}</th>
+                                <th class="r">{% trans "Translated" %}</th>
+                                <th class="info-tip r" title="{% trans "Fuzzy entries call for revision by the translator." %}">{% trans "Fuzzy" %}</th>
+                                <th class="r">{% trans "Obsolete" %}</th>
+                                <th>{% trans "File" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for app,path,po in pos %}
+                                <tr class="{% cycle 'row1' 'row2' %}">
+                                    <td><a href="{% url 'rosetta-form' po_filter=po_filter lang_id=lid idx=forloop.counter0 %}">{{ app|title }}</a></td>
+                                    <td class="ch-progress r">{{ po.percent_translated }}%</td>
+                                    {% with po.untranslated_entries|length as len_untranslated_entries %}
+                                        <td class="ch-messages r">{{ po.translated_entries|length|add:len_untranslated_entries }}</td>
+                                    {% endwith %}
+                                    <td class="ch-translated r">{{ po.translated_entries|length }}</td>
+                                    <td class="ch-fuzzy r">{{ po.fuzzy_entries|length }}</td>
+                                    <td class="ch-obsolete r">{{ po.obsolete_entries|length }}</td>
+                                    <td class="hint">{{ path }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        {% endfor %}
     {% else %}
-    <h1>{% trans "Nothing to translate!" %}</h1>
-    <p>{% trans "You haven't specified any languages in your settings file, or haven't yet generated a batch of translation catalogs." %}</p>
-    <p>{% blocktrans with "http://docs.djangoproject.com/en/dev/topics/i18n/#topics-i18n" as i18n_doc_link  %}Please refer to <a href="{{i18n_doc_link}}">Django's I18N documentation</a> for a guide on how to set up internationalization for your project.{% endblocktrans %}</p>
+        <h1>{% trans "Nothing to translate!" %}</h1>
+        <p>{% trans "You haven't specified any languages in your settings file, or haven't yet generated a batch of translation catalogs." %}</p>
+        <p>{% blocktrans with "http://docs.djangoproject.com/en/dev/topics/i18n/#topics-i18n" as i18n_doc_link %}Please refer to <a href="{{ i18n_doc_link }}">Django's I18N documentation</a> for a guide on how to set up internationalization for your project.{% endblocktrans %}</p>
     {% endif %}
 {% endblock %}

--- a/rosetta/templates/rosetta/form.html
+++ b/rosetta/templates/rosetta/form.html
@@ -2,36 +2,36 @@
 {% load rosetta i18n %}
 
 {% block header %}
-    {{block.super}}
+    {{ block.super }}
     <div id="user-tools">
         <p>
             <span><a href="{% url 'rosetta-file-list' po_filter=po_filter %}">{% trans "Pick another file" %}</a> /
-            <a href="{% url 'rosetta-download-file' po_filter=po_filter lang_id=lang_id idx=idx %}">{% trans "Download this catalog" %}</a></span>
+                <a href="{% url 'rosetta-download-file' po_filter=po_filter lang_id=lang_id idx=idx %}">{% trans "Download this catalog" %}</a></span>
         </p>
     </div>
 {% endblock %}
 
-{% block pagetitle %}{{block.super}} - {{rosetta_settings.MESSAGES_SOURCE_LANGUAGE_NAME}} - {{rosetta_i18n_lang_name}} ({{ rosetta_i18n_pofile.percent_translated }}%){% endblock %}
+{% block pagetitle %}{{ block.super }} - {{ rosetta_settings.MESSAGES_SOURCE_LANGUAGE_NAME }} - {{ rosetta_i18n_lang_name }} ({{ rosetta_i18n_pofile.percent_translated }}%){% endblock %}
 
 {% block breadcumbs %}
     <div>
         <a href="{% url 'rosetta-file-list' po_filter=po_filter %}">{% trans "Home" %}</a> &rsaquo;
         {{ rosetta_i18n_lang_name }} &rsaquo;
         {{ rosetta_i18n_app|title }} &rsaquo;
-        {% blocktrans with rosetta_i18n_pofile.percent_translated as percent_translated  %}Progress: {{ percent_translated }}%{% endblocktrans %}
+        {% blocktrans with rosetta_i18n_pofile.percent_translated as percent_translated %}Progress: {{ percent_translated }}%{% endblocktrans %}
     </div>
     {% if not rosetta_i18n_write %}<p class="errornote read-only">{% trans "File is read-only: download the file when done editing!" %}</p>{% endif %}
     {% if messages %}
         <div class="messages errornote save-conflict">
-        {% for message in messages %}
-            <p class="{{message.tags}}">{{ message|linebreaks }}</p>
-        {% endfor %}
+            {% for message in messages %}
+                <p class="{{ message.tags }}">{{ message|linebreaks }}</p>
+            {% endfor %}
         </div>
     {% endif %}
 {% endblock %}
 
 {% block main %}
-    <h1>{% blocktrans  %}Translate into {{rosetta_i18n_lang_name}}{% endblocktrans %}</h1>
+    <h1>{% blocktrans %}Translate into {{ rosetta_i18n_lang_name }}{% endblocktrans %}</h1>
 
     <ul class="object-tools">
         <li class="nobubble">{% trans "Display:" %}</li>
@@ -47,21 +47,21 @@
             <form id="changelist-search" action="" method="get">
                 <div>
                     <label for="searchbar"><img src="{% static "admin/img/icon_searchbox_rosetta.png" %}" alt="{% trans "Search" %}" /></label>
-                    <input type="text" size="40" name="query" value="{% if query %}{{query}}{% endif %}" id="searchbar" tabindex="0" />
+                    <input type="text" size="40" name="query" value="{% if query %}{{ query }}{% endif %}" id="searchbar" tabindex="0" />
                     <input type="submit" name="s" value="{% trans "Go" %}" />
                 </div>
             </form>
         </div>
 
         {% if rosetta_settings.ENABLE_REFLANG %}
-        <div class="actions">
-            <label for="ref-language-selector">{% trans "Reference language" %}:</label>
-            <select class="select-across" id="ref-language-selector" onchange="javascript:window.location.href = this.value;">
-                {% for langid, langname in LANGUAGES %}
-                    <option{% if ref_lang == langid %} selected="selected"{% endif %} value="?ref_lang={{ langid }}">{{langname}}</option>
-                {% endfor %}
-            </select>
-        </div>
+            <div class="actions">
+                <label for="ref-language-selector">{% trans "Reference language" %}:</label>
+                <select class="select-across" id="ref-language-selector" onchange="javascript:window.location.href = this.value;">
+                    {% for langid, langname in LANGUAGES %}
+                        <option{% if ref_lang == langid %} selected="selected"{% endif %} value="?ref_lang={{ langid }}">{{ langname }}</option>
+                    {% endfor %}
+                </select>
+            </div>
         {% endif %}
 
         <form method="post" action="" class="results">
@@ -78,89 +78,89 @@
                 </thead>
                 <tbody>
                     {% for message in rosetta_messages %}
-                    <tr class="{% cycle 'row1' 'row2' %}">
-                        {% if message.msgid_plural %}
-                            <td class="original plural">
-                                <div class="plural-container">
-                                    <span class="part">{{message.msgid|format_message|linebreaksbr}}</span>
-                                    <span class="part">{{message.msgid_plural|format_message|linebreaksbr}}</span>
-                                </div>
-                            </td>
-                            <td class="translation">
-                                {% for k, msgstr in message.msgstr_plural.items %}
-                                    <label for="m_{{message.md5hash}}_{{k}}">{{k}}:</label>
-                                    <textarea rows="{{message.msgid|format_message|lines_count}}" cols="40" id="m_{{message.md5hash}}_{{k}}" name="m_{{message.md5hash}}_{{k}}" tabindex="{% increment tab_idx %}">{{msgstr}}</textarea>
-                                {% endfor %}
-                            </td>
-                        {% else %}
-                            <td class="original">
-                                {% if rosetta_settings.ENABLE_REFLANG %}
-                                <span class="message">{{ message.ref_txt|format_message|linebreaksbr }}</span>
-                                {% else %}
-                                <span class="message">{{ message.msgid|format_message|linebreaksbr }}</span>
-                                {% endif %}
-                            </td>
-                            {% if main_language %}<td class="original">{{ message.main_lang|format_message|linebreaksbr }}</td>{% endif %}
-                            <td class="translation">
-                                <textarea rows="{{message.msgid|format_message|lines_count}}" cols="40" name="m_{{message.md5hash}}" tabindex="{% increment tab_idx %}">{{message.msgstr}}</textarea>
-                                {% if rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS %}<a href="#" class="suggest">{% trans "suggest" %}</a>{% endif %}
-                            </td>
-                        {% endif %}
+                        <tr class="{% cycle 'row1' 'row2' %}">
+                            {% if message.msgid_plural %}
+                                <td class="original plural">
+                                    <div class="plural-container">
+                                        <span class="part">{{ message.msgid|format_message|linebreaksbr }}</span>
+                                        <span class="part">{{ message.msgid_plural|format_message|linebreaksbr }}</span>
+                                    </div>
+                                </td>
+                                <td class="translation">
+                                    {% for k, msgstr in message.msgstr_plural.items %}
+                                        <label for="m_{{ message.md5hash }}_{{ k }}">{{ k }}:</label>
+                                        <textarea rows="{{ message.msgid|format_message|lines_count }}" cols="40" id="m_{{ message.md5hash }}_{{ k }}" name="m_{{ message.md5hash }}_{{ k }}" tabindex="{% increment tab_idx %}">{{ msgstr }}</textarea>
+                                    {% endfor %}
+                                </td>
+                            {% else %}
+                                <td class="original">
+                                    {% if rosetta_settings.ENABLE_REFLANG %}
+                                        <span class="message">{{ message.ref_txt|format_message|linebreaksbr }}</span>
+                                    {% else %}
+                                        <span class="message">{{ message.msgid|format_message|linebreaksbr }}</span>
+                                    {% endif %}
+                                </td>
+                                {% if main_language %}<td class="original">{{ message.main_lang|format_message|linebreaksbr }}</td>{% endif %}
+                                <td class="translation">
+                                    <textarea rows="{{ message.msgid|format_message|lines_count }}" cols="40" name="m_{{ message.md5hash }}" tabindex="{% increment tab_idx %}">{{ message.msgstr }}</textarea>
+                                    {% if rosetta_settings.ENABLE_TRANSLATION_SUGGESTIONS %}<a href="#" class="suggest">{% trans "suggest" %}</a>{% endif %}
+                                </td>
+                            {% endif %}
                             <td class="c">
-                                <input type="checkbox" name="f_{{message.md5hash}}" value="1" {% if message|is_fuzzy %}checked="checked"{% endif %} />
+                                <input type="checkbox" name="f_{{ message.md5hash }}" value="1" {% if message|is_fuzzy %}checked="checked"{% endif %} />
                             </td>
                             {% if rosetta_settings.SHOW_OCCURRENCES %}
-                            <td class="location">
-                                {% for fn,lineno in message.occurrences %}
-                                    <code{% if forloop.counter|gt:"3" %} class="hide"{% endif %}>{{ fn }}{% if lineno %}:{{lineno}}{% endif %}</code>
-                                {% endfor %}
-                                {% if message.occurrences|length|gt:"3" %}
-                                    <a href="#">&hellip; ({% blocktrans count message.occurrences|length|minus:"3" as more_count %}{{more_count}} more{% plural %}{{more_count}} more{% endblocktrans %})</a>
-                                {% endif %}
-                                {% if message.msgctxt or message.comment %}
-                                    <span class="context">
-                                    {% trans "Context hint" %}:
-                                    {% if message.msgctxt %}
-                                        {{message.msgctxt|safe}}
+                                <td class="location">
+                                    {% for fn,lineno in message.occurrences %}
+                                        <code{% if forloop.counter|gt:"3" %} class="hide"{% endif %}>{{ fn }}{% if lineno %}:{{ lineno }}{% endif %}</code>
+                                    {% endfor %}
+                                    {% if message.occurrences|length|gt:"3" %}
+                                        <a href="#">&hellip; ({% blocktrans count message.occurrences|length|minus:"3" as more_count %}{{ more_count }} more{% plural %}{{ more_count }} more{% endblocktrans %})</a>
                                     {% endif %}
-                                    {% if message.msgctxt and message.comment %}<br/>{% endif %}
-                                    {% if message.comment %}
-                                        {{message.comment|safe}}
+                                    {% if message.msgctxt or message.comment %}
+                                        <span class="context">
+                                            {% trans "Context hint" %}:
+                                            {% if message.msgctxt %}
+                                                {{ message.msgctxt|safe }}
+                                            {% endif %}
+                                            {% if message.msgctxt and message.comment %}<br/>{% endif %}
+                                            {% if message.comment %}
+                                                {{ message.comment|safe }}
+                                            {% endif %}
+                                        </span>
                                     {% endif %}
-                                    </span>
-                                {% endif %}
-                            </td>{% endif %}
-                    </tr>
+                                </td>{% endif %}
+                        </tr>
                     {% endfor %}
                 </tbody>
             </table>
             <div class="submit-row">
                 <p class="paginator">
                     {% if query %}
-                        <input type="hidden" name="query" value="{{query}}"  />
+                        <input type="hidden" name="query" value="{{ query }}"  />
                     {% endif %}
                     <input type="submit" class="default" name="_next" value="{% trans "Save and translate next block" %}" tabindex="{% increment tab_idx %}"/>
 
 
                     {% if needs_pagination %}
-                    {% trans "Skip to page:" %}
-                    {% for i in page_range %}
-                        {% if i == '...' %}
-                        <span class="space">{{ i }}</span>
-                        {% else %}
-                        {% if i == page %}
-                            <span class="this-page">{{i}}</span>
-                        {% else %}
-                            <a href="?{{ pagination_query_string_base }}&amp;page={{i}}">{{i}}</a>
-                        {% endif %}
-                        {% endif %}
-                    {% endfor %}
+                        {% trans "Skip to page:" %}
+                        {% for i in page_range %}
+                            {% if i == '...' %}
+                                <span class="space">{{ i }}</span>
+                            {% else %}
+                                {% if i == page %}
+                                    <span class="this-page">{{ i }}</span>
+                                {% else %}
+                                    <a href="?{{ pagination_query_string_base }}&amp;page={{ i }}">{{ i }}</a>
+                                {% endif %}
+                            {% endif %}
+                        {% endfor %}
                     {% else %}
-                    {% trans "Displaying:" %}
+                        {% trans "Displaying:" %}
                     {% endif %}
 
                     {% with paginator.object_list|length as hits %}
-                    <strong>{% blocktrans count rosetta_i18n_pofile|length as message_number %}{{hits}}/{{message_number}} message{% plural %}{{hits}}/{{message_number}} messages{% endblocktrans %}</strong>
+                        <strong>{% blocktrans count rosetta_i18n_pofile|length as message_number %}{{ hits }}/{{ message_number }} message{% plural %}{{ hits }}/{{ message_number }} messages{% endblocktrans %}</strong>
                     {% endwith %}
 
 

--- a/rosetta/translate_utils.py
+++ b/rosetta/translate_utils.py
@@ -22,7 +22,7 @@ def translate(text, from_language, to_language):
     if DEEPL_AUTH_KEY:
         deepl_language_code = None
         DEEPL_LANGUAGES = getattr(settings, "DEEPL_LANGUAGES", None)
-        if type(DEEPL_LANGUAGES) is dict:
+        if isinstance(DEEPL_LANGUAGES, dict):
             deepl_language_code = DEEPL_LANGUAGES.get(to_language, None)
 
         if deepl_language_code is None:

--- a/testproject/templates/test.html
+++ b/testproject/templates/test.html
@@ -2,7 +2,7 @@
 
 {% trans "Some text to translate" %}
 
-{% blocktrans %}
+{% blocktrans trimmed %}
     one bottle of beer on the wall
 {% plural %}
     {{ num_bottles }} bottles of beer on the wall

--- a/testproject/templates/test.html
+++ b/testproject/templates/test.html
@@ -3,7 +3,7 @@
 {% trans "Some text to translate" %}
 
 {% blocktrans %}
-one bottle of beer on the wall
+    one bottle of beer on the wall
 {% plural %}
-{{num_bottles}} bottles of beer on the wall
+    {{ num_bottles }} bottles of beer on the wall
 {% endblocktrans %}


### PR DESCRIPTION
- [x] Are tests passing? (From the root-level of the repository please run `pip install tox && tox`)
- [x] I have added or updated a test to cover the changes proposed in this Pull Request
- [x] I have updated the documentation to cover the changes proposed in this Pull Request

Tests passed locally with `tox` and I these shouldn't require any test or docs changes. Also tested manually with the `testproject`.

----

This PR adds auto formatting with pre-commit for js/css/html, and some minor linting tweaks:

* Fixed `flake8` url, which has been changed a while ago from `gitlab` to `github`
* Reformatted `rosetta.css` and `rosetta.js` with `prettier`
* Added `eslint` config (using v8 because couldn't get the newer v9 config working)
* Fixed a few `eslint` warnings in `rosetta.js`
* Reformatted django templates with `djhtml`
* Added `trimmed` to `blocktrans` in `test.html` since the indentation was changed, but I guess this would be done in practice too to ignore the newlines.
* `prettier` works for `yaml` files too but not added that here

I tried to stick to the defaults mostly, but I'm happy to redo this with different settings if needed.