### PR TITLE
fix the dead line in the docs to i18n topic

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -28,7 +28,7 @@ Translating Rosetta itself
 By default Rosetta hides its own catalog files in the file selection interface (shown above.) If you would like to translate Rosetta to your own language:
 
 1. Create a subdirectory for your locale inside Rosetta's ``locale`` directory, e.g. ``rosetta/locale/XX/LC_MESSAGES``
-2. Instruct Django to create the initial catalog, by running ``django-admin.py  makemessages -l XX`` inside Rosetta's directory (refer to `Django's documentation on i18n <http://www.djangoproject.com/documentation/i18n/>`_ for details)
+2. Instruct Django to create the initial catalog, by running ``django-admin.py  makemessages -l XX`` inside Rosetta's directory (refer to `Django's documentation on i18n <https://docs.djangoproject.com/en/stable/topics/i18n/>`_ for details)
 3. Instruct Rosetta to look for its own catalogs, by appending `?rosetta` to the language selection page's URL, e.g. ``http://127.0.0.1:8000/rosetta/pick/?rosetta``
 4. Translate as usual
 5. Send a pull request if you feel like sharing


### PR DESCRIPTION
Documentation fix: the usage page (https://django-rosetta.readthedocs.io/usage.html) links to a dead link in the Django documentation (http://www.djangoproject.com/documentation/i18n/). Fixed with a more recent one.